### PR TITLE
build: Update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ jobs:
         - ares-deps
         platform:
         - name: windows-x64
-          os: windows-latest
+          os: windows-2025
           compiler: clang++
           windres: windres
           shell: 'msys2 {0}'
           msystem: clang64
           install: mingw-w64-clang-x86_64-clang
         - name: windows-arm64
-          os: windows-latest
+          os: windows-2025
           compiler: clang++ --target=aarch64-w64-windows-gnu --sysroot=/clangarm64 -resource-dir=/clangarm64/lib/clang/$(basename "$(clang++ -print-resource-dir)")
           windres: windres --target=aarch64-w64-windows-gnu
           shell: 'msys2 {0}'
@@ -80,11 +80,12 @@ jobs:
         envName: ${{ matrix.platform.name }}
       run: |
         ./build_deps.sh RelWithDebInfo
+        tar -cvJf ares-deps.tar.xz ares-deps
     - name: Publish Build Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: ares-deps-${{ matrix.platform.name }}
-        path: ${{ github.workspace }}/ares-deps
+        path: ${{ github.workspace }}/ares-deps.tar.xz
   make-release:
     name: Create and upload release
     permissions:
@@ -105,6 +106,16 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         
+      - name: Decompress build artifacts
+        run: |
+          : Decompress build artifacts
+          ls **/*
+          for package in macos-universal linux-universal windows-x64 windows-arm64; do
+            tar -xJf ares-deps-${package}/ares-deps.tar.xz
+            rm -rf ares-deps-${package}
+            mv ares-deps ares-deps-${package}
+          done
+          
       - name: Package Dependencies
         run: |
           : Package Dependencies

--- a/deps.linux/slang_shaders
+++ b/deps.linux/slang_shaders
@@ -1,7 +1,7 @@
 slang_shaders_name='slang-shaders'
 slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
-slang_shaders_hash='ec1b8556388317258376467c1561ecb91a06a466'
+slang_shaders_hash='25311dc03332d9ef2dff8d9d06c611d828028fac'
 
 ## Build Steps
 slang_shaders_setup() {

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -24,14 +24,19 @@ librashader_clean() {
 }
 
 librashader_patch() {
-  echo "No patching to perform"
+  cd librashader
+  echo "Pinning nightly Rust version to 2025-03-21"
+  echo $'[toolchain]' > rust-toolchain.toml
+  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
+  echo $'targets = [ \"x86_64-apple-darwin\", \"aarch64-apple-darwin\" ]' >> rust-toolchain.toml
+  cd ..
 }
 
 librashader_build() {
   cd librashader
   export RUSTFLAGS=-g
-  cargo +nightly run -p librashader-build-script -- --profile ${librashader_profile} --target x86_64-apple-darwin
-  cargo +nightly run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-apple-darwin
+  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target x86_64-apple-darwin
+  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-apple-darwin
   lipo -create -output target/${librashader_profile}/librashader.dylib target/x86_64-apple-darwin/${librashader_profile}/librashader.dylib target/aarch64-apple-darwin/${librashader_profile}/librashader.dylib
   lipo -create -output target/${librashader_profile}/librashader.dylib.dSYM target/x86_64-apple-darwin/${librashader_profile}/deps/liblibrashader_capi.dylib.dSYM/Contents/Resources/DWARF/liblibrashader_capi.dylib target/aarch64-apple-darwin/${librashader_profile}/deps/liblibrashader_capi.dylib.dSYM/Contents/Resources/DWARF/liblibrashader_capi.dylib
   cd ..

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -17,6 +17,7 @@ librashader_setup() {
   elif [[ $config == "Release" ]]; then
     librashader_profile='optimized'
   fi
+  export MACOSX_DEPLOYMENT_TARGET=10.15
 }
 
 librashader_clean() {

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -1,7 +1,7 @@
 librashader_name='librashader'
-librashader_version='0.5.1'
+librashader_version='0.6.3'
 librashader_url='https://github.com/SnowflakePowered/librashader.git'
-librashader_hash='cbdbdafecdfd6113ef1cdc15e0a4140b46420f0b'
+librashader_hash='029cd36cdf4963e8d9501d912689549254f50f0c'
 librashader_profile='release'
 
 librashader_setup() {

--- a/deps.macos/moltenvk
+++ b/deps.macos/moltenvk
@@ -10,6 +10,7 @@ moltenvk_setup() {
     git -C MoltenVK fetch
   fi
   git -C MoltenVK reset --hard "$moltenvk_hash"
+  export MACOSX_DEPLOYMENT_TARGET=10.15
 }
 
 moltenvk_clean() {

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -18,18 +18,11 @@ sdl_setup() {
     git -C SDL fetch
   fi
   git -C SDL reset --hard "$sdl_hash"
+  export MACOSX_DEPLOYMENT_TARGET=10.15
 }
 
 sdl_clean() {
   echo "Todo"
-}
-
-sdl_config() {
-  if [[ "$config" == "RelWithDebInfo" ]]; then
-    CFLAGS='-g'
-  elif [[ "$config" == "Debug" ]]; then
-    CFLAGS='-O0 -g'
-  fi
 }
 
 sdl_patch() {

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -1,13 +1,19 @@
-sdl_name='SDL2'
-sdl_version='2.30.8'
+sdl_name='SDL3'
+sdl_version='3.2.8'
 sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='79ec168f3c1e2fe27335cb8886439f7ef676fb49'
+sdl_hash='f6864924f76e1a0b4abaefc76ae2ed22b1a8916e'
 SDLARGS=()
 
 ## Build Steps
 sdl_setup() {
   if [ ! -d "SDL" ]; then
-    git clone https://github.com/libsdl-org/SDL.git
+    git clone ${sdl_url}
+  else
+    git -C SDL fetch
+  fi
+  git -C SDL reset --hard "$sdl_hash"
+  if [ ! -d "SDL" ]; then
+    git clone ${sdl_url}
   else
     git -C SDL fetch
   fi
@@ -33,11 +39,11 @@ sdl_patch() {
 sdl_build() {
   SDLARGS=()
   SDLARGS+=("-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64;")
-
+  
   cd SDL
   
   xcodebuild build -project ./Xcode/SDL/SDL.xcodeproj \
-                   -scheme "Shared Library" \
+                   -scheme "SDL3" \
                    archive \
                    -configuration $config \
                    DEBUG_INFORMATION_FORMAT="dwarf-with-dsym" \
@@ -45,16 +51,14 @@ sdl_build() {
                    ARCHS="x86_64 arm64" \
                    ONLY_ACTIVE_ARCH=FALSE \
                    2>&1 | xcbeautify --renderer github-actions
+
   cd ..
 }
 
 sdl_install() {
-  ditto build_temp/SDL/build.xcarchive/Products/@rpath/libSDL2.dylib ares-deps/lib/libSDL2.dylib
-  ditto build_temp/SDL/build.xcarchive/dSYMs/libSDL2.dylib.dSYM ares-deps/lib/libSDL2.dylib.dSYM
-  mkdir -p ares-deps/include/SDL2
-  ditto build_temp/SDL/build.xcarchive/Products/usr/local/include ares-deps/include/SDL2
-  ditto build_temp/SDL/include/SDL_metal.h build_temp/SDL/include/SDL_locale.h build_temp/SDL/include/SDL_misc.h ares-deps/include/SDL2
-  ditto build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL2/LICENSE.txt
+  ditto build_temp/SDL/build.xcarchive/Products/Library/Frameworks/SDL3.framework ares-deps/lib/SDL3.framework
+  ditto build_temp/SDL/build.xcarchive/dSYMs/SDL3.framework.dSYM ares-deps/lib/SDL3.framework.dSYM
+  ditto build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL/LICENSE.txt
 }
 
 

--- a/deps.macos/slang_shaders
+++ b/deps.macos/slang_shaders
@@ -17,10 +17,6 @@ slang_shaders_clean() {
   echo "Todo"
 }
 
-slang_shaders_config() {
-  echo "No configuration to perform"
-}
-
 slang_shaders_patch() {
   echo "No patching to perform"
 }

--- a/deps.macos/slang_shaders
+++ b/deps.macos/slang_shaders
@@ -1,7 +1,7 @@
 slang_shaders_name='slang-shaders'
 slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
-slang_shaders_hash='7e2975e90632c93bc879707362469e6c9a3027b0'
+slang_shaders_hash='25311dc03332d9ef2dff8d9d06c611d828028fac'
 
 ## Build Steps
 slang_shaders_setup() {

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -1,7 +1,7 @@
 librashader_name='librashader'
-librashader_version='0.5.1'
+librashader_version='0.6.3'
 librashader_url='https://github.com/SnowflakePowered/librashader.git'
-librashader_hash='cbdbdafecdfd6113ef1cdc15e0a4140b46420f0b'
+librashader_hash='029cd36cdf4963e8d9501d912689549254f50f0c'
 librashader_profile='release'
 
 librashader_setup() {

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -24,16 +24,21 @@ librashader_clean() {
 }
 
 librashader_patch() {
-  echo "No patching to perform"
+  cd librashader
+  echo "Pinning nightly Rust version to 2025-03-21"
+  echo $'[toolchain]' > rust-toolchain.toml
+  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
+  echo $'targets = [ \"aarch64-pc-windows-msvc\", \"x86_64-pc-windows-msvc\" ]' >> rust-toolchain.toml
+  cd ..
 }
 
 librashader_build() {
   cd librashader
   if [[ $envName = windows-arm64 ]]; then
     echo "Targeting aarch64..."
-    cargo +nightly run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc
+    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc
   else
-    cargo +nightly run -p librashader-build-script -- --profile ${librashader_profile}
+    cargo run -p librashader-build-script -- --profile ${librashader_profile}
   fi
   cd ..
 }

--- a/deps.windows/sdl
+++ b/deps.windows/sdl
@@ -1,13 +1,13 @@
-sdl_name='SDL2'
-sdl_version='2.30.8'
+sdl_name='SDL3'
+sdl_version='3.2.8'
 sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='79ec168f3c1e2fe27335cb8886439f7ef676fb49'
+sdl_hash='f6864924f76e1a0b4abaefc76ae2ed22b1a8916e'
 SDLARGS=()
 
 ## Build Steps
 sdl_setup() {
   if [ ! -d "SDL" ]; then
-    git clone https://github.com/libsdl-org/SDL.git
+    git clone ${sdl_url}
   else
     git -C SDL fetch
   fi
@@ -53,16 +53,16 @@ sdl_build() {
 
 sdl_install() {
   mkdir -p ares-deps/lib
-  mkdir -p ares-deps/include/SDL2
-  mkdir -p ares-deps/licenses/SDL2
-  cp -R build_temp/SDL/build/${config}/SDL2.dll ares-deps/lib/SDL2.dll
-  cp -R build_temp/SDL/build/${config}/SDL2.pdb ares-deps/lib/SDL2.pdb
-  cp -R build_temp/SDL/build/${config}/SDL2.exp ares-deps/lib/SDL2.exp
-  cp -R build_temp/SDL/build/${config}/SDL2.lib ares-deps/lib/SDL2.lib
-  mkdir -p ares-deps/include/SDL2
-  cp -R build_temp/SDL/build/include/SDL2/. ares-deps/include/SDL2/
-  cp -R build_temp/SDL/build/include-config-${config}/SDL2/. ares-deps/include/SDL2/
-  cp -R build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL2/LICENSE.txt
+  mkdir -p ares-deps/include/SDL3
+  mkdir -p ares-deps/licenses/SDL3
+  cp -R build_temp/SDL/build/${config}/SDL3.dll ares-deps/lib/SDL3.dll
+  cp -R build_temp/SDL/build/${config}/SDL3.pdb ares-deps/lib/SDL3.pdb
+  cp -R build_temp/SDL/build/${config}/SDL3.exp ares-deps/lib/SDL3.exp
+  cp -R build_temp/SDL/build/${config}/SDL3.lib ares-deps/lib/SDL3.lib
+  mkdir -p ares-deps/include/SDL3
+  cp -R build_temp/SDL/include/SDL3/. ares-deps/include/SDL3/
+  cp -R build_temp/SDL/build/include-config-${config}/build_config/. ares-deps/include/SDL3/
+  cp -R build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL3/LICENSE.txt
 }
 
 

--- a/deps.windows/slang_shaders
+++ b/deps.windows/slang_shaders
@@ -1,7 +1,7 @@
 slang_shaders_name='slang-shaders'
 slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
-slang_shaders_hash='ec1b8556388317258376467c1561ecb91a06a466'
+slang_shaders_hash='25311dc03332d9ef2dff8d9d06c611d828028fac'
 
 ## Build Steps
 slang_shaders_setup() {


### PR DESCRIPTION
* Update SDL to SDL 3.2.8 on both macOS and Windows
* Update librashader to 0.6.2 on both macOS and Windows
* Update slang-shaders to current master-ish on macOS, Windows and Linux

Updates the Windows runner to windows-2025, because building SDL3 is broken on `windows-latest`.