### PR TITLE
Update SDL to 3.2.10

### DIFF
--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -1,7 +1,7 @@
 sdl_name='SDL3'
-sdl_version='3.2.8'
+sdl_version='3.2.10'
 sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='f6864924f76e1a0b4abaefc76ae2ed22b1a8916e'
+sdl_hash='877399b2b2cf21e67554ed9046410f268ce1d1b2'
 SDLARGS=()
 
 ## Build Steps

--- a/deps.windows/sdl
+++ b/deps.windows/sdl
@@ -1,7 +1,7 @@
 sdl_name='SDL3'
-sdl_version='3.2.8'
+sdl_version='3.2.10'
 sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='f6864924f76e1a0b4abaefc76ae2ed22b1a8916e'
+sdl_hash='877399b2b2cf21e67554ed9046410f268ce1d1b2'
 SDLARGS=()
 
 ## Build Steps


### PR DESCRIPTION
3.2.10 contains a fix for "controller GUIDs changing randomly on Windows", which sounds relevant for us, so I figure we may as well get this in before tagging another ares-deps version.

CI run here: https://github.com/jcm93/ares-deps-2/actions/runs/14247426126/job/39931814497