### PR TITLE
Update dependencies (post-v146)

### DIFF
--- a/deps.linux/slang_shaders
+++ b/deps.linux/slang_shaders
@@ -1,7 +1,7 @@
 slang_shaders_name='slang-shaders'
 slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
-slang_shaders_hash='8c630e0d3234d93b6c2bc847371f86aa4e535686'
+slang_shaders_hash='c9303dcc4d11fe5d37db9ef9a24c8eab4087c0c3'
 
 ## Build Steps
 slang_shaders_setup() {

--- a/deps.macos/moltenvk
+++ b/deps.macos/moltenvk
@@ -1,7 +1,7 @@
 moltenvk_name='MoltenVK'
-moltenvk_version='1.3.0'
+moltenvk_version='1.4.0'
 moltenvk_url='https://github.com/KhronosGroup/MoltenVK.git'
-moltenvk_hash='49b97f26ae013b9e5bfb3098ee5dea5e4f58e9e8'
+moltenvk_hash='458870543b9bcf6b0edd6f90aaa776707b310d96'
 
 moltenvk_setup() {
   if [ ! -d "MoltenVK" ]; then

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -1,7 +1,7 @@
 sdl_name='SDL3'
-sdl_version='3.2.14'
+sdl_version='3.2.20'
 sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='8d604353a53853fa56d1bdce0363535605ca868f'
+sdl_hash='96292a5b464258a2b926e0a3d72f8b98c2a81aa6'
 SDLARGS=()
 
 ## Build Steps

--- a/deps.macos/slang_shaders
+++ b/deps.macos/slang_shaders
@@ -1,7 +1,7 @@
 slang_shaders_name='slang-shaders'
 slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
-slang_shaders_hash='8c630e0d3234d93b6c2bc847371f86aa4e535686'
+slang_shaders_hash='c9303dcc4d11fe5d37db9ef9a24c8eab4087c0c3'
 
 ## Build Steps
 slang_shaders_setup() {

--- a/deps.windows/sdl
+++ b/deps.windows/sdl
@@ -1,7 +1,7 @@
 sdl_name='SDL3'
-sdl_version='3.2.14'
+sdl_version='3.2.20'
 sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='8d604353a53853fa56d1bdce0363535605ca868f'
+sdl_hash='96292a5b464258a2b926e0a3d72f8b98c2a81aa6'
 SDLARGS=("-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded")
 
 ## Build Steps

--- a/deps.windows/slang_shaders
+++ b/deps.windows/slang_shaders
@@ -1,7 +1,7 @@
 slang_shaders_name='slang-shaders'
 slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
-slang_shaders_hash='8c630e0d3234d93b6c2bc847371f86aa4e535686'
+slang_shaders_hash='c9303dcc4d11fe5d37db9ef9a24c8eab4087c0c3'
 
 ## Build Steps
 slang_shaders_setup() {


### PR DESCRIPTION
* Update SDL to SDL 3.2.20 on macOS and Windows
* Update MoltenVK to 1.4.0 on macOS
* Update slang-shaders to ref `c9303dc` on macOS, Windows and Linux