### PR TITLE
Add SDL3 3.4.0 dependency for Linux

### DIFF
--- a/deps.linux/sdl
+++ b/deps.linux/sdl
@@ -1,0 +1,71 @@
+sdl_name='SDL3'
+sdl_version='3.4.0'
+sdl_url='https://github.com/libsdl-org/SDL.git'
+sdl_hash='a962f40bbba175e9716557a25d5d7965f134a3d3'
+
+## Build Steps
+sdl_setup() {
+  echo "[SDL3] cloning"
+  if [ ! -d "SDL" ]; then
+    git clone ${sdl_url}
+  else
+    git -C SDL fetch
+  fi
+  git -C SDL reset --hard "$sdl_hash"
+  echo "[SDL3] cloning -- success"
+}
+
+sdl_package_source() {
+  echo "[SDL3] packaging source"
+  mkdir -p ../ares-deps-source/src/SDL/
+  cp -R SDL/. ../ares-deps-source/src/SDL
+  echo "[SDL3] packaging source -- success"
+}
+
+sdl_clean() {
+  echo "[SDL3] cleaning up -- skipped"
+}
+
+sdl_patch() {
+  echo "[SDL3] patching -- skipped"
+}
+
+sdl_build() {
+  echo "[SDL3] building"
+  cd SDL
+  mkdir -p build
+  pushd build
+
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=${config} \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DSDL_SHARED=ON \
+    -DSDL_STATIC=OFF \
+    -DSDL_X11_XTEST=OFF
+
+  cmake --build . --config ${config} --parallel
+
+  popd
+  cd ..
+  echo "[SDL3] building -- success"
+}
+
+sdl_install() {
+  echo "[SDL3] installing"
+  mkdir -p ares-deps/lib
+  mkdir -p ares-deps/include/SDL3
+  mkdir -p ares-deps/licenses/SDL3
+
+  # Install shared library and symlinks
+  cp -P build_temp/SDL/build/libSDL3.so* ares-deps/lib/
+
+  # Install headers
+  cp -R build_temp/SDL/include/SDL3/. ares-deps/include/SDL3/
+  cp -R build_temp/SDL/build/include-config-${config}/build_config/. ares-deps/include/SDL3/ 2>/dev/null || \
+  cp -R build_temp/SDL/build/include/SDL3/. ares-deps/include/SDL3/ 2>/dev/null || true
+
+  # Install license
+  cp build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL3/LICENSE.txt
+
+  echo "[SDL3] installing -- success"
+}


### PR DESCRIPTION
## Summary
- Adds SDL3 3.4.0 build script for Linux, matching the existing Windows and macOS configurations
- Uses the same version and git hash as other platforms for consistency

## Motivation

This is particularly useful for **snap packaging** where SDL3's native joystick support provides significant advantages:

- **Better security model**: SDL3's joystick API allows using the `joystick` snap plug instead of `hardware-observe`
- **Reduced privileges**: The `hardware-observe` plug requires elevated privileges via udev device monitoring, while the `joystick` plug is more restricted and sandboxed
- **Consistency**: Aligns Linux with Windows and macOS which already have SDL3 in their dependencies

## Test plan
- [x] Build succeeds on Linux with the new dependency
- [x] SDL3 shared library is correctly installed to `ares-deps/lib/`
- [x] Headers are installed to `ares-deps/include/SDL3/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)