### PR TITLE
Add librashader 0.9.1 dependency for Linux

### DIFF
--- a/deps.linux/librashader
+++ b/deps.linux/librashader
@@ -1,0 +1,72 @@
+librashader_name='librashader'
+librashader_version='0.9.1'
+librashader_url='https://github.com/SnowflakePowered/librashader.git'
+librashader_hash='ad661b661c3d10cb4a2573a78a41857330d499ca'
+librashader_profile='release'
+
+librashader_setup() {
+  echo "[librashader] cloning"
+  if [ ! -d "librashader" ]; then
+    git clone https://github.com/SnowflakePowered/librashader.git
+  else
+    git -C librashader fetch
+  fi
+  git -C librashader reset --hard "$librashader_hash"
+
+  if [[ $config == "Debug" ]]; then
+    librashader_profile='debug'
+  elif [[ $config == "Release" ]]; then
+    librashader_profile='optimized'
+  fi
+  echo "[librashader] cloning -- success"
+}
+
+librashader_package_source() {
+  echo "[librashader] packaging source"
+  mkdir -p ../ares-deps-source/src/librashader
+  cp -R librashader/. ../ares-deps-source/src/librashader
+  echo "[librashader] packaging source -- success"
+}
+
+librashader_clean() {
+  echo "[librashader] cleaning up -- skipped"
+}
+
+librashader_patch() {
+  echo "[librashader] patching source"
+  cd librashader
+  echo "Pinning nightly Rust version to 2025-03-21"
+  echo '[toolchain]' > rust-toolchain.toml
+  echo 'channel = "nightly-2025-03-21"' >> rust-toolchain.toml
+  echo 'targets = [ "x86_64-unknown-linux-gnu" ]' >> rust-toolchain.toml
+  cd ..
+  echo "[librashader] patching source -- success"
+}
+
+librashader_build() {
+  echo "[librashader] building"
+  cd librashader
+  export RUSTFLAGS=-g
+  cargo run -p librashader-build-script -- --profile ${librashader_profile}
+  cd ..
+  echo "[librashader] building -- success"
+}
+
+librashader_install() {
+  echo "[librashader] installing"
+  mkdir -p ares-deps/include/librashader/
+  mkdir -p ares-deps/lib/
+  mkdir -p ares-deps/licenses/librashader/
+
+  # Install headers
+  cp -R build_temp/librashader/include/. ares-deps/include/librashader/
+
+  # Install shared library
+  cp build_temp/librashader/target/${librashader_profile}/librashader.so ares-deps/lib/librashader.so
+
+  # Install licenses
+  cp build_temp/librashader/LICENSE.md ares-deps/licenses/librashader/LICENSE.md
+  cp build_temp/librashader/LICENSE-GPL.md ares-deps/licenses/librashader/LICENSE-GPL.md
+
+  echo "[librashader] installing -- success"
+}


### PR DESCRIPTION
## Summary
- Adds librashader 0.9.1 build script for Linux, matching the existing Windows and macOS configurations
- Uses the same version and git hash as other platforms for consistency

## Motivation

Complements #12 (SDL3 for Linux) to provide full parity with Windows/macOS dependency builds.

This enables Linux distributions (including snap packages) to use the same prebuilt dependency workflow as other platforms.

## Test plan
- [x] Build succeeds on Linux with the new dependency
- [x] librashader.so is correctly installed to `ares-deps/lib/`
- [x] Headers are installed to `ares-deps/include/librashader/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)