### PR TITLE
Rewrite README: comprehensive project documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 on:
   push:
-  schedule:
-    - cron: 20 0 * * *
   workflow_dispatch:
 jobs:
   build:
@@ -30,8 +28,12 @@ jobs:
           os: macos-latest
           compiler: clang++
           shell: sh
-        - name: linux-universal
+        - name: linux-x64
           os: ubuntu-latest
+          compiler: clang++
+          shell: sh
+        - name: linux-arm64
+          os: ubuntu-24.04-arm
           compiler: clang++
           shell: sh
     name: ${{ matrix.program }}-${{ matrix.platform.name }}
@@ -128,7 +130,7 @@ jobs:
         run: |
           : Decompress build artifacts
           ls **/*
-          for package in macos-universal linux-universal windows-x64 windows-arm64; do
+          for package in macos-universal linux-x64 linux-arm64 windows-x64 windows-arm64; do
             tar -xJf ares-deps-${package}/ares-deps.tar.xz
             rm -rf ares-deps-${package}
             mv ares-deps ares-deps-${package}
@@ -175,5 +177,6 @@ jobs:
             ${{ github.workspace }}/ares-deps-windows-x64*.*
             ${{ github.workspace }}/ares-deps-windows-arm64*.*
             ${{ github.workspace }}/ares-deps-macos-universal*.*
-            ${{ github.workspace }}/ares-deps-linux-universal*.*
+            ${{ github.workspace }}/ares-deps-linux-x64*.*
+            ${{ github.workspace }}/ares-deps-linux-arm64*.*
        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,17 @@ jobs:
         rustup default nightly
         rustup target add x86_64-apple-darwin
         rustup target add aarch64-apple-darwin
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential pkg-config cmake git \
+          libasound2-dev libpulse-dev libudev-dev \
+          libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev libxss-dev \
+          libwayland-dev libxkbcommon-dev libegl-dev libdrm-dev libgbm-dev \
+          libvulkan-dev
+        rustup toolchain install nightly
+        rustup default nightly
     - name: Set up MSVC environment
       if: matrix.platform.msvc-arch != ''
       uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,9 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Get Metadata
         id: metadata
         run: |
@@ -157,8 +160,30 @@ jobs:
           for file in ${{ github.workspace }}/@(*.tar.xz|*.zip); do
             echo "    ${file##*/}: $(sha256sum "${file}" | cut -d " " -f 1)" >> ${{ github.workspace }}/CHECKSUMS.txt
           done
-          ls
-          ls ${{ github.workspace }}/*
+
+      - name: Generate deps.json
+        run: |
+          : Generate deps.json
+          SDL_VERSION=$(grep "^sdl_version=" deps.linux/sdl | cut -d"'" -f2)
+          LIBRASHADER_VERSION=$(grep "^librashader_version=" deps.linux/librashader | cut -d"'" -f2)
+          HASH_LINUX_X64=$(sha256sum ${{ github.workspace }}/ares-deps-linux-x64.tar.xz | cut -d" " -f1)
+          HASH_LINUX_ARM64=$(sha256sum ${{ github.workspace }}/ares-deps-linux-arm64.tar.xz | cut -d" " -f1)
+
+          cat > ${{ github.workspace }}/deps.json <<EOF
+          {
+            "version": "${{ steps.metadata.outputs.version }}",
+            "baseUrl": "https://github.com/${{ github.repository }}/releases/download",
+            "sdlVersion": "${SDL_VERSION}",
+            "librashaderVersion": "${LIBRASHADER_VERSION}",
+            "hashes": {
+              "linux-x64": "${HASH_LINUX_X64}",
+              "linux-arm64": "${HASH_LINUX_ARM64}"
+            }
+          }
+          EOF
+
+          echo "Generated deps.json:"
+          cat ${{ github.workspace }}/deps.json
 
       - name: Create Release
         id: create_release
@@ -170,6 +195,7 @@ jobs:
           name: ares dependencies, build ${{ steps.metadata.outputs.version }}
           body_path: ${{ github.workspace }}/CHECKSUMS.txt
           files: |
+            ${{ github.workspace }}/deps.json
             ${{ github.workspace }}/ares-deps-windows-x64*.*
             ${{ github.workspace }}/ares-deps-windows-arm64*.*
             ${{ github.workspace }}/ares-deps-macos-universal*.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,21 +53,17 @@ jobs:
     - name: Install Windows Dependencies
       if: runner.os == 'Windows'
       run: |
-        export PATH="/c/Users/runneradmin/.cargo/bin:$PATH" # correct on windows-latest as of 2024-02-19
+        export PATH="/c/Users/runneradmin/.cargo/bin:$PATH"
+        rustup toolchain install stable
+        rustup default stable
         if [[ ${{ matrix.platform.name }} == *-arm64 ]]; then
-          rustup toolchain install nightly
-          rustup default nightly
           rustup target add aarch64-pc-windows-msvc
-        else
-          rustup toolchain install nightly
-          rustup default nightly
         fi
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
-        brew install ninja cmake xcbeautify
-        rustup toolchain install nightly
-        rustup default nightly
+        rustup toolchain install stable
+        rustup default stable
         rustup target add x86_64-apple-darwin
         rustup target add aarch64-apple-darwin
     - name: Install Linux Dependencies
@@ -79,8 +75,8 @@ jobs:
           libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev libxss-dev \
           libwayland-dev libxkbcommon-dev libegl-dev libdrm-dev libgbm-dev \
           libvulkan-dev
-        rustup toolchain install nightly
-        rustup default nightly
+        rustup toolchain install stable
+        rustup default stable
     - name: Set up MSVC environment
       if: matrix.platform.msvc-arch != ''
       uses: ilammy/msvc-dev-cmd@v1
@@ -125,7 +121,7 @@ jobs:
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
-        
+
       - name: Decompress build artifacts
         run: |
           : Decompress build artifacts
@@ -134,17 +130,17 @@ jobs:
             tar -xJf ares-deps-${package}/ares-deps.tar.xz
             rm -rf ares-deps-${package}
             mv ares-deps ares-deps-${package}
-            
+
             tar -xJf ares-deps-${package}-source/ares-deps-source.tar.xz
             rm -rf ares-deps-${package}-source
             mv ares-deps-source ares-deps-${package}-source
           done
-          
+
       - name: Package Dependencies
         run: |
           : Package Dependencies
           shopt -s extglob
-          
+
           for dir in */; do
               dir_name="${dir%/}"
               tar -cvJf "${dir_name}.tar.xz" "$dir"
@@ -179,4 +175,4 @@ jobs:
             ${{ github.workspace }}/ares-deps-macos-universal*.*
             ${{ github.workspace }}/ares-deps-linux-x64*.*
             ${{ github.workspace }}/ares-deps-linux-arm64*.*
-       
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,19 +55,19 @@ jobs:
       run: |
         export PATH="/c/Users/runneradmin/.cargo/bin:$PATH" # correct on windows-latest as of 2024-02-19
         if [[ ${{ matrix.platform.name }} == *-arm64 ]]; then
-          rustup toolchain install stable
-          rustup default stable
+          rustup toolchain install nightly
+          rustup default nightly
           rustup target add aarch64-pc-windows-msvc
         else
-          rustup toolchain install stable
-          rustup default stable
+          rustup toolchain install nightly
+          rustup default nightly
         fi
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
         brew install ninja cmake xcbeautify
-        rustup toolchain install stable
-        rustup default stable
+        rustup toolchain install nightly
+        rustup default nightly
         rustup target add x86_64-apple-darwin
         rustup target add aarch64-apple-darwin
     - name: Install Linux Dependencies
@@ -79,8 +79,8 @@ jobs:
           libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev libxss-dev \
           libwayland-dev libxkbcommon-dev libegl-dev libdrm-dev libgbm-dev \
           libvulkan-dev
-        rustup toolchain install stable
-        rustup default stable
+        rustup toolchain install nightly
+        rustup default nightly
     - name: Set up MSVC environment
       if: matrix.platform.msvc-arch != ''
       uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,19 +165,37 @@ jobs:
         run: |
           : Generate deps.json
           SDL_VERSION=$(grep "^sdl_version=" deps.linux/sdl | cut -d"'" -f2)
+          SDL_URL=$(grep "^sdl_url=" deps.linux/sdl | cut -d"'" -f2 | sed 's/\.git$//')
           LIBRASHADER_VERSION=$(grep "^librashader_version=" deps.linux/librashader | cut -d"'" -f2)
+          LIBRASHADER_URL=$(grep "^librashader_url=" deps.linux/librashader | cut -d"'" -f2 | sed 's/\.git$//')
+          SLANG_SHADERS_VERSION=$(grep "^slang_shaders_version=" deps.linux/slang_shaders | cut -d"'" -f2)
+          SLANG_SHADERS_HASH=$(grep "^slang_shaders_hash=" deps.linux/slang_shaders | cut -d"'" -f2)
+          SLANG_SHADERS_URL=$(grep "^slang_shaders_url=" deps.linux/slang_shaders | cut -d"'" -f2 | sed 's/\.git$//')
+          MOLTENVK_VERSION=$(grep "^moltenvk_version=" deps.macos/moltenvk | cut -d"'" -f2)
+          MOLTENVK_URL=$(grep "^moltenvk_url=" deps.macos/moltenvk | cut -d"'" -f2 | sed 's/\.git$//')
+
           HASH_LINUX_X64=$(sha256sum ${{ github.workspace }}/ares-deps-linux-x64.tar.xz | cut -d" " -f1)
           HASH_LINUX_ARM64=$(sha256sum ${{ github.workspace }}/ares-deps-linux-arm64.tar.xz | cut -d" " -f1)
+          HASH_MACOS=$(sha256sum ${{ github.workspace }}/ares-deps-macos-universal.tar.xz | cut -d" " -f1)
+          HASH_WINDOWS_X64=$(sha256sum ${{ github.workspace }}/ares-deps-windows-x64.tar.xz | cut -d" " -f1)
+          HASH_WINDOWS_ARM64=$(sha256sum ${{ github.workspace }}/ares-deps-windows-arm64.tar.xz | cut -d" " -f1)
 
           cat > ${{ github.workspace }}/deps.json <<EOF
           {
             "version": "${{ steps.metadata.outputs.version }}",
             "baseUrl": "https://github.com/${{ github.repository }}/releases/download",
-            "sdlVersion": "${SDL_VERSION}",
-            "librashaderVersion": "${LIBRASHADER_VERSION}",
+            "dependencies": {
+              "sdl": { "version": "${SDL_VERSION}", "tag": "release-${SDL_VERSION}", "url": "${SDL_URL}" },
+              "librashader": { "version": "${LIBRASHADER_VERSION}", "tag": "librashader-v${LIBRASHADER_VERSION}", "url": "${LIBRASHADER_URL}" },
+              "slang-shaders": { "version": "${SLANG_SHADERS_VERSION}", "commit": "${SLANG_SHADERS_HASH}", "url": "${SLANG_SHADERS_URL}" },
+              "moltenvk": { "version": "${MOLTENVK_VERSION}", "tag": "v${MOLTENVK_VERSION}", "url": "${MOLTENVK_URL}" }
+            },
             "hashes": {
               "linux-x64": "${HASH_LINUX_X64}",
-              "linux-arm64": "${HASH_LINUX_ARM64}"
+              "linux-arm64": "${HASH_LINUX_ARM64}",
+              "macos-universal": "${HASH_MACOS}",
+              "windows-x64": "${HASH_WINDOWS_X64}",
+              "windows-arm64": "${HASH_WINDOWS_ARM64}"
             }
           }
           EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,19 +55,19 @@ jobs:
       run: |
         export PATH="/c/Users/runneradmin/.cargo/bin:$PATH" # correct on windows-latest as of 2024-02-19
         if [[ ${{ matrix.platform.name }} == *-arm64 ]]; then
-          rustup toolchain install nightly
-          rustup default nightly
+          rustup toolchain install stable
+          rustup default stable
           rustup target add aarch64-pc-windows-msvc
         else
-          rustup toolchain install nightly
-          rustup default nightly
+          rustup toolchain install stable
+          rustup default stable
         fi
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
         brew install ninja cmake xcbeautify
-        rustup toolchain install nightly
-        rustup default nightly
+        rustup toolchain install stable
+        rustup default stable
         rustup target add x86_64-apple-darwin
         rustup target add aarch64-apple-darwin
     - name: Install Linux Dependencies
@@ -79,8 +79,8 @@ jobs:
           libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev libxss-dev \
           libwayland-dev libxkbcommon-dev libegl-dev libdrm-dev libgbm-dev \
           libvulkan-dev
-        rustup toolchain install nightly
-        rustup default nightly
+        rustup toolchain install stable
+        rustup default stable
     - name: Set up MSVC environment
       if: matrix.platform.msvc-arch != ''
       uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
   schedule:
     - cron: 20 0 * * *
+  workflow_dispatch:
 jobs:
   build:
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,27 +1,153 @@
 # ares-deps
 
-ares-deps is a group of build scripts for precompiling and packaging dependencies for [ares](https://github.com/ares-emulator/ares) on macOS and Windows. ares-deps also pre-packages certain non-library resources for Linux.
+Cross-platform dependency build system for the [ares emulator](https://github.com/ares-emulator/ares).
 
-ares-deps is designed to be pulled in at configure/generation time when building ares, such that any necessary libraries and data can be included and linked appropriately, and finally packaged correctly in the app bundle or rundir as appropriate.
+Builds, packages and distributes precompiled libraries and resources needed by ares on all supported platforms.
 
-## Running
+## Dependencies
 
-If you need to compile ares-deps locally, run `./build_deps.sh <config>`, providing either `<Debug|Release|RelWithDebInfo|MinSizeRel>` for the configuration.
+| Dependency | Version | Source | Strategy |
+|---|---|---|---|
+| [SDL3](https://github.com/libsdl-org/SDL) | 3.4.0 | `release-3.4.0` tag | Pre-built (Windows/macOS), compiled from source (Linux) |
+| [librashader](https://github.com/SnowflakePowered/librashader) | 0.9.1 | `librashader-v0.9.1` tag | Compiled from source (all platforms, Rust stable) |
+| [slang-shaders](https://github.com/libretro/slang-shaders) | 1.0 | commit `46dcd51d` | Cloned and cleaned (no compilation) |
+| [MoltenVK](https://github.com/KhronosGroup/MoltenVK) | 1.4.1 | `v1.4.1` tag | Pre-built (macOS only) |
 
-## Dependency specifics
+### Platform matrix
 
-Dependency build functions are provided in a `<dependency>` file in the `deps.macos`, `deps.windows`, or `deps.linux` directory as appropriate. These files should define the following functions that will build and package the dependency:
+| Dependency | Linux x64 | Linux arm64 | macOS universal | Windows x64 | Windows arm64 |
+|---|---|---|---|---|---|
+| SDL3 | compiled | compiled | pre-built DMG | pre-built ZIP | pre-built ZIP |
+| librashader | compiled | compiled | compiled (lipo universal) | compiled | compiled (cross aarch64) |
+| slang-shaders | cloned | cloned | cloned | cloned | cloned |
+| MoltenVK | - | - | pre-built tar | - | - |
 
-* `<dependency>_setup()`: This function should clone the repository, checkout a specific commit, and perform any other setup required to build, such as mapping build configurations if necessary.
-* `<dependency>_patch()`: This function should apply any necessary patches to the code prior to building.
-* `<dependency>_build()`: This function should build the library in the provided configuration.
+## Build locally
 
-The above three functions are called from within the `build_temp` working directory.
+```bash
+./build_deps.sh <config>   # config: Debug | Release | RelWithDebInfo | MinSizeRel
+```
 
-* `<dependency>_install()`: This function should copy build products to the final output directory. The product directory is named `ares-deps` and should be treated as a prefix; that is, it will contain `lib`, `share`, `include`, etc. directories per Unix-like prefix structures.
-  * The `lib` folder should contain all .dylibs or .dlls for the library, as well as all debug symbol files.
-  * The `include/<dependency>/` directory should contain any necessary header files for the library.
-  * Data dependencies go into the `share` folder.
-  * Any relevant licenses for the library should be placed in the `licenses/<dependency>/` directory and named appropriately.
-  
-This last function is called from the base directory of this repository.
+The script auto-detects the platform (Linux/macOS/Windows) and loads the appropriate scripts from `deps.<os>/`. Output goes to the `ares-deps/` directory with a standard Unix prefix structure.
+
+### Prerequisites
+
+- **All platforms**: Rust stable toolchain
+- **Linux**: CMake, build-essential, SDL3 build dependencies (X11, Wayland, audio, Vulkan dev packages)
+- **macOS**: Xcode command line tools, Rust targets for `x86_64-apple-darwin` and `aarch64-apple-darwin`
+- **Windows**: MSYS2 with clang64, Rust target `aarch64-pc-windows-msvc` (for arm64 builds)
+
+## Architecture
+
+### Build lifecycle
+
+For each dependency, `build_deps.sh` calls these functions in order:
+
+1. `<dep>_setup()` — Clone repo / download pre-built package
+2. `<dep>_patch()` — Apply patches (currently none)
+3. `<dep>_package_source()` — Archive source for debug symbols
+4. `<dep>_build()` — Compile (or skip for pre-built packages)
+5. `<dep>_install()` — Copy artifacts to `ares-deps/` prefix
+
+Steps 1-4 run from the `build_temp/` directory. Step 5 runs from the repository root.
+
+### Output structure
+
+```
+ares-deps/
+├── lib/              # .so, .dylib, .dll, .lib, .pdb
+├── include/          # Header files (SDL3/, librashader/)
+├── share/            # Shader presets (slang-shaders)
+└── licenses/         # License files per dependency
+```
+
+### Dependency scripts
+
+Each dependency is defined in a platform-specific file:
+
+```
+deps.linux/          deps.macos/          deps.windows/
+├── sdl              ├── sdl              ├── sdl
+├── librashader      ├── librashader      ├── librashader
+└── slang_shaders    ├── slang_shaders    └── slang_shaders
+                     └── moltenvk
+```
+
+Each file declares metadata variables (`_name`, `_version`, `_url`) and implements the 5 lifecycle functions.
+
+## CI/CD
+
+### Build workflow
+
+On every push and tag, GitHub Actions builds dependencies for all 5 platforms in parallel:
+
+| Platform | Runner | Rust targets |
+|---|---|---|
+| `linux-x64` | `ubuntu-latest` | default |
+| `linux-arm64` | `ubuntu-24.04-arm` | default |
+| `macos-universal` | `macos-latest` | `x86_64-apple-darwin` + `aarch64-apple-darwin` |
+| `windows-x64` | `windows-2025` (MSYS2) | default |
+| `windows-arm64` | `windows-2025` (MSYS2) | `aarch64-pc-windows-msvc` |
+
+### Release workflow
+
+When a tag is pushed (e.g. `2025.02.06`), the `make-release` job runs after all builds succeed:
+
+1. Downloads all 5 platform artifacts
+2. Repackages them as `ares-deps-<platform>.tar.xz`
+3. Generates SHA256 checksums
+4. **Generates `deps.json`** — extracts versions and URLs from build scripts, computes hashes
+5. Creates a GitHub release with all archives and `deps.json`
+
+### deps.json
+
+The `deps.json` file is automatically generated during releases and published as a release asset. It serves as a machine-readable manifest for consumers (e.g. [ares-snap](https://github.com/Le-Syl21/ares-snap)).
+
+```json
+{
+  "version": "2025.02.06",
+  "baseUrl": "https://github.com/Le-Syl21/ares-deps/releases/download",
+  "dependencies": {
+    "sdl":           { "version": "3.4.0", "tag": "release-3.4.0",         "url": "https://github.com/libsdl-org/SDL" },
+    "librashader":   { "version": "0.9.1", "tag": "librashader-v0.9.1",   "url": "https://github.com/SnowflakePowered/librashader" },
+    "slang-shaders": { "version": "1.0",   "commit": "46dcd51d...",        "url": "https://github.com/libretro/slang-shaders" },
+    "moltenvk":      { "version": "1.4.1", "tag": "v1.4.1",               "url": "https://github.com/KhronosGroup/MoltenVK" }
+  },
+  "hashes": {
+    "linux-x64":        "<sha256>",
+    "linux-arm64":      "<sha256>",
+    "macos-universal":  "<sha256>",
+    "windows-x64":      "<sha256>",
+    "windows-arm64":    "<sha256>"
+  }
+}
+```
+
+| Field | Description |
+|---|---|
+| `version` | Release tag (used in download URLs) |
+| `baseUrl` | GitHub releases base URL |
+| `dependencies.<dep>.version` | Upstream version string |
+| `dependencies.<dep>.tag` | Git tag used for checkout/download |
+| `dependencies.<dep>.commit` | Pinned commit hash (when no tag exists) |
+| `dependencies.<dep>.url` | Upstream repository URL |
+| `hashes.<platform>` | SHA256 of `ares-deps-<platform>.tar.xz` |
+
+### Creating a release
+
+```bash
+git tag 2025.02.06 -m "Release description"
+git push origin 2025.02.06
+```
+
+The CI builds all platforms, generates `deps.json`, and publishes the release automatically.
+
+## Updating a dependency
+
+1. Edit the version in the relevant `deps.<os>/<dep>` files (all platforms)
+2. Commit, push, create a new tag
+3. Update `deps.json` in consumer repos (e.g. ares-snap) with the new release version and hashes
+
+## License
+
+Dependencies are distributed under their respective licenses, included in `ares-deps/licenses/`.

--- a/deps.linux/librashader
+++ b/deps.linux/librashader
@@ -31,9 +31,9 @@ librashader_package_source() {
 librashader_patch() {
   echo "[librashader] patching source"
   cd librashader
-  echo "Pinning Rust to stable 1.93.0"
+  echo "Pinning nightly Rust version to 2025-03-21"
   echo '[toolchain]' > rust-toolchain.toml
-  echo 'channel = "1.93.0"' >> rust-toolchain.toml
+  echo 'channel = "nightly-2025-03-21"' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"
 }
@@ -42,7 +42,7 @@ librashader_build() {
   echo "[librashader] building"
   cd librashader
   export RUSTFLAGS=-g
-  cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --features=stable
+  cargo run -p librashader-build-script -- --profile ${librashader_profile}
   cd ..
   echo "[librashader] building -- success"
 }

--- a/deps.linux/librashader
+++ b/deps.linux/librashader
@@ -1,23 +1,10 @@
 librashader_name='librashader'
 librashader_version='0.9.1'
 librashader_url='https://github.com/SnowflakePowered/librashader.git'
-librashader_hash='ad661b661c3d10cb4a2573a78a41857330d499ca'
-librashader_profile='release'
 
 librashader_setup() {
   echo "[librashader] cloning"
-  if [ ! -d "librashader" ]; then
-    git clone https://github.com/SnowflakePowered/librashader.git
-  else
-    git -C librashader fetch
-  fi
-  git -C librashader reset --hard "$librashader_hash"
-
-  if [[ $config == "Debug" ]]; then
-    librashader_profile='debug'
-  elif [[ $config == "Release" ]]; then
-    librashader_profile='optimized'
-  fi
+  git clone --branch librashader-v${librashader_version} --depth 1 ${librashader_url}
   echo "[librashader] cloning -- success"
 }
 
@@ -29,20 +16,13 @@ librashader_package_source() {
 }
 
 librashader_patch() {
-  echo "[librashader] patching source"
-  cd librashader
-  echo "Pinning nightly Rust version to 2025-03-21"
-  echo '[toolchain]' > rust-toolchain.toml
-  echo 'channel = "nightly-2025-03-21"' >> rust-toolchain.toml
-  cd ..
-  echo "[librashader] patching source -- success"
+  echo "[librashader] patching -- skipped"
 }
 
 librashader_build() {
   echo "[librashader] building"
   cd librashader
-  export RUSTFLAGS=-g
-  cargo run -p librashader-build-script -- --profile ${librashader_profile}
+  cargo build --release -p librashader-capi --features=stable
   cd ..
   echo "[librashader] building -- success"
 }
@@ -53,13 +33,8 @@ librashader_install() {
   mkdir -p ares-deps/lib/
   mkdir -p ares-deps/licenses/librashader/
 
-  # Install headers
   cp -R build_temp/librashader/include/. ares-deps/include/librashader/
-
-  # Install shared library
-  cp build_temp/librashader/target/${librashader_profile}/librashader.so ares-deps/lib/librashader.so
-
-  # Install licenses
+  cp build_temp/librashader/target/release/liblibrashader_capi.so ares-deps/lib/librashader.so
   cp build_temp/librashader/LICENSE.md ares-deps/licenses/librashader/LICENSE.md
   cp build_temp/librashader/LICENSE-GPL.md ares-deps/licenses/librashader/LICENSE-GPL.md
 

--- a/deps.linux/librashader
+++ b/deps.linux/librashader
@@ -1,0 +1,72 @@
+librashader_name='librashader'
+librashader_version='0.9.1'
+librashader_url='https://github.com/SnowflakePowered/librashader.git'
+librashader_hash='ad661b661c3d10cb4a2573a78a41857330d499ca'
+librashader_profile='release'
+
+librashader_setup() {
+  echo "[librashader] cloning"
+  if [ ! -d "librashader" ]; then
+    git clone https://github.com/SnowflakePowered/librashader.git
+  else
+    git -C librashader fetch
+  fi
+  git -C librashader reset --hard "$librashader_hash"
+
+  if [[ $config == "Debug" ]]; then
+    librashader_profile='debug'
+  elif [[ $config == "Release" ]]; then
+    librashader_profile='optimized'
+  fi
+  echo "[librashader] cloning -- success"
+}
+
+librashader_package_source() {
+  echo "[librashader] packaging source"
+  mkdir -p ../ares-deps-source/src/librashader
+  cp -R librashader/. ../ares-deps-source/src/librashader
+  echo "[librashader] packaging source -- success"
+}
+
+librashader_clean() {
+  echo "[librashader] cleaning up -- skipped"
+}
+
+librashader_patch() {
+  echo "[librashader] patching source"
+  cd librashader
+  echo "Pinning nightly Rust version to 2025-03-21"
+  echo '[toolchain]' > rust-toolchain.toml
+  echo 'channel = "nightly-2025-03-21"' >> rust-toolchain.toml
+  echo 'targets = [ "x86_64-unknown-linux-gnu" ]' >> rust-toolchain.toml
+  cd ..
+  echo "[librashader] patching source -- success"
+}
+
+librashader_build() {
+  echo "[librashader] building"
+  cd librashader
+  export RUSTFLAGS=-g
+  cargo run -p librashader-build-script -- --profile ${librashader_profile}
+  cd ..
+  echo "[librashader] building -- success"
+}
+
+librashader_install() {
+  echo "[librashader] installing"
+  mkdir -p ares-deps/include/librashader/
+  mkdir -p ares-deps/lib/
+  mkdir -p ares-deps/licenses/librashader/
+
+  # Install headers
+  cp -R build_temp/librashader/include/. ares-deps/include/librashader/
+
+  # Install shared library
+  cp build_temp/librashader/target/${librashader_profile}/librashader.so ares-deps/lib/librashader.so
+
+  # Install licenses
+  cp build_temp/librashader/LICENSE.md ares-deps/licenses/librashader/LICENSE.md
+  cp build_temp/librashader/LICENSE-GPL.md ares-deps/licenses/librashader/LICENSE-GPL.md
+
+  echo "[librashader] installing -- success"
+}

--- a/deps.linux/librashader
+++ b/deps.linux/librashader
@@ -38,7 +38,6 @@ librashader_patch() {
   echo "Pinning nightly Rust version to 2025-03-21"
   echo '[toolchain]' > rust-toolchain.toml
   echo 'channel = "nightly-2025-03-21"' >> rust-toolchain.toml
-  echo 'targets = [ "x86_64-unknown-linux-gnu" ]' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"
 }

--- a/deps.linux/librashader
+++ b/deps.linux/librashader
@@ -42,7 +42,7 @@ librashader_build() {
   echo "[librashader] building"
   cd librashader
   export RUSTFLAGS=-g
-  cargo run -p librashader-build-script -- --profile ${librashader_profile}
+  cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --features=stable
   cd ..
   echo "[librashader] building -- success"
 }

--- a/deps.linux/librashader
+++ b/deps.linux/librashader
@@ -28,16 +28,12 @@ librashader_package_source() {
   echo "[librashader] packaging source -- success"
 }
 
-librashader_clean() {
-  echo "[librashader] cleaning up -- skipped"
-}
-
 librashader_patch() {
   echo "[librashader] patching source"
   cd librashader
-  echo "Pinning nightly Rust version to 2025-03-21"
+  echo "Pinning Rust to stable 1.93.0"
   echo '[toolchain]' > rust-toolchain.toml
-  echo 'channel = "nightly-2025-03-21"' >> rust-toolchain.toml
+  echo 'channel = "1.93.0"' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"
 }

--- a/deps.linux/sdl
+++ b/deps.linux/sdl
@@ -57,15 +57,10 @@ sdl_install() {
   # Install headers
   cp -R build_temp/SDL/include/SDL3/. ares-deps/include/SDL3/
 
-  # Install generated build config header (path varies by SDL version)
-  if [ -d "build_temp/SDL/build/include-config-${config}/build_config" ]; then
-    cp -R build_temp/SDL/build/include-config-${config}/build_config/. ares-deps/include/SDL3/
-  elif [ -d "build_temp/SDL/build/include/SDL3" ]; then
-    cp -R build_temp/SDL/build/include/SDL3/. ares-deps/include/SDL3/
-  else
-    echo "ERROR: SDL build config headers not found" >&2
-    exit 1
-  fi
+  # Install generated build config header
+  # SDL3 CMake uses $<LOWER_CASE:$<CONFIG>> so the directory name is always lowercase
+  local config_lower=$(echo "${config}" | tr '[:upper:]' '[:lower:]')
+  cp -R build_temp/SDL/build/include-config-${config_lower}/build_config/. ares-deps/include/SDL3/
 
   # Install license
   cp build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL3/LICENSE.txt

--- a/deps.linux/sdl
+++ b/deps.linux/sdl
@@ -22,10 +22,6 @@ sdl_package_source() {
   echo "[SDL3] packaging source -- success"
 }
 
-sdl_clean() {
-  echo "[SDL3] cleaning up -- skipped"
-}
-
 sdl_patch() {
   echo "[SDL3] patching -- skipped"
 }
@@ -38,7 +34,6 @@ sdl_build() {
 
   cmake .. \
     -DCMAKE_BUILD_TYPE=${config} \
-    -DCMAKE_INSTALL_PREFIX=/usr \
     -DSDL_SHARED=ON \
     -DSDL_STATIC=OFF \
     -DSDL_X11_XTEST=OFF
@@ -61,8 +56,16 @@ sdl_install() {
 
   # Install headers
   cp -R build_temp/SDL/include/SDL3/. ares-deps/include/SDL3/
-  cp -R build_temp/SDL/build/include-config-${config}/build_config/. ares-deps/include/SDL3/ 2>/dev/null || \
-  cp -R build_temp/SDL/build/include/SDL3/. ares-deps/include/SDL3/ 2>/dev/null || true
+
+  # Install generated build config header (path varies by SDL version)
+  if [ -d "build_temp/SDL/build/include-config-${config}/build_config" ]; then
+    cp -R build_temp/SDL/build/include-config-${config}/build_config/. ares-deps/include/SDL3/
+  elif [ -d "build_temp/SDL/build/include/SDL3" ]; then
+    cp -R build_temp/SDL/build/include/SDL3/. ares-deps/include/SDL3/
+  else
+    echo "ERROR: SDL build config headers not found" >&2
+    exit 1
+  fi
 
   # Install license
   cp build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL3/LICENSE.txt

--- a/deps.linux/sdl
+++ b/deps.linux/sdl
@@ -1,17 +1,10 @@
 sdl_name='SDL3'
 sdl_version='3.4.0'
 sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='a962f40bbba175e9716557a25d5d7965f134a3d3'
 
-## Build Steps
 sdl_setup() {
   echo "[SDL3] cloning"
-  if [ ! -d "SDL" ]; then
-    git clone ${sdl_url}
-  else
-    git -C SDL fetch
-  fi
-  git -C SDL reset --hard "$sdl_hash"
+  git clone --branch release-${sdl_version} --depth 1 ${sdl_url} SDL
   echo "[SDL3] cloning -- success"
 }
 
@@ -29,40 +22,24 @@ sdl_patch() {
 sdl_build() {
   echo "[SDL3] building"
   cd SDL
-  mkdir -p build
-  pushd build
-
-  cmake .. \
-    -DCMAKE_BUILD_TYPE=${config} \
+  cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$SCRIPT_DIR/ares-deps" \
     -DSDL_SHARED=ON \
     -DSDL_STATIC=OFF \
+    -DSDL_TEST=OFF \
     -DSDL_X11_XTEST=OFF
-
-  cmake --build . --config ${config} --parallel
-
-  popd
+  cmake --build build --parallel
   cd ..
   echo "[SDL3] building -- success"
 }
 
 sdl_install() {
   echo "[SDL3] installing"
-  mkdir -p ares-deps/lib
-  mkdir -p ares-deps/include/SDL3
   mkdir -p ares-deps/licenses/SDL3
 
-  # Install shared library and symlinks
-  cp -P build_temp/SDL/build/libSDL3.so* ares-deps/lib/
+  cmake --install build_temp/SDL/build
 
-  # Install headers
-  cp -R build_temp/SDL/include/SDL3/. ares-deps/include/SDL3/
-
-  # Install generated build config header
-  # SDL3 CMake uses $<LOWER_CASE:$<CONFIG>> so the directory name is always lowercase
-  local config_lower=$(echo "${config}" | tr '[:upper:]' '[:lower:]')
-  cp -R build_temp/SDL/build/include-config-${config_lower}/build_config/. ares-deps/include/SDL3/
-
-  # Install license
   cp build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL3/LICENSE.txt
 
   echo "[SDL3] installing -- success"

--- a/deps.linux/sdl
+++ b/deps.linux/sdl
@@ -1,0 +1,71 @@
+sdl_name='SDL3'
+sdl_version='3.4.0'
+sdl_url='https://github.com/libsdl-org/SDL.git'
+sdl_hash='a962f40bbba175e9716557a25d5d7965f134a3d3'
+
+## Build Steps
+sdl_setup() {
+  echo "[SDL3] cloning"
+  if [ ! -d "SDL" ]; then
+    git clone ${sdl_url}
+  else
+    git -C SDL fetch
+  fi
+  git -C SDL reset --hard "$sdl_hash"
+  echo "[SDL3] cloning -- success"
+}
+
+sdl_package_source() {
+  echo "[SDL3] packaging source"
+  mkdir -p ../ares-deps-source/src/SDL/
+  cp -R SDL/. ../ares-deps-source/src/SDL
+  echo "[SDL3] packaging source -- success"
+}
+
+sdl_clean() {
+  echo "[SDL3] cleaning up -- skipped"
+}
+
+sdl_patch() {
+  echo "[SDL3] patching -- skipped"
+}
+
+sdl_build() {
+  echo "[SDL3] building"
+  cd SDL
+  mkdir -p build
+  pushd build
+
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=${config} \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DSDL_SHARED=ON \
+    -DSDL_STATIC=OFF \
+    -DSDL_X11_XTEST=OFF
+
+  cmake --build . --config ${config} --parallel
+
+  popd
+  cd ..
+  echo "[SDL3] building -- success"
+}
+
+sdl_install() {
+  echo "[SDL3] installing"
+  mkdir -p ares-deps/lib
+  mkdir -p ares-deps/include/SDL3
+  mkdir -p ares-deps/licenses/SDL3
+
+  # Install shared library and symlinks
+  cp -P build_temp/SDL/build/libSDL3.so* ares-deps/lib/
+
+  # Install headers
+  cp -R build_temp/SDL/include/SDL3/. ares-deps/include/SDL3/
+  cp -R build_temp/SDL/build/include-config-${config}/build_config/. ares-deps/include/SDL3/ 2>/dev/null || \
+  cp -R build_temp/SDL/build/include/SDL3/. ares-deps/include/SDL3/ 2>/dev/null || true
+
+  # Install license
+  cp build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL3/LICENSE.txt
+
+  echo "[SDL3] installing -- success"
+}

--- a/deps.linux/slang_shaders
+++ b/deps.linux/slang_shaders
@@ -3,14 +3,12 @@ slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
 slang_shaders_hash='46dcd51d14efd2d49505d932d6b979f141f538d8'
 
-## Build Steps
 slang_shaders_setup() {
-  if [ ! -d "slang-shaders" ]; then
-    git clone https://github.com/libretro/slang-shaders.git
-  else
-    git -C slang-shaders fetch
-  fi
-  git -C slang-shaders reset --hard "$slang_shaders_hash"
+  echo "[slang_shaders] cloning"
+  git clone --depth 1 ${slang_shaders_url}
+  git -C slang-shaders fetch --depth 1 origin ${slang_shaders_hash}
+  git -C slang-shaders checkout ${slang_shaders_hash}
+  echo "[slang_shaders] cloning -- success"
 }
 
 slang_shaders_package_source() {
@@ -22,15 +20,17 @@ slang_shaders_patch() {
 }
 
 slang_shaders_build() {
+  echo "[slang_shaders] cleaning source tree"
   cd slang-shaders
   rm -rf .git
-  rm -f .gitlab-ci.yml
-  rm -f configure
-  rm -f Makefile
+  rm -f .gitlab-ci.yml configure Makefile
   cd ..
+  echo "[slang_shaders] cleaning source tree -- success"
 }
 
 slang_shaders_install() {
+  echo "[slang_shaders] installing"
   mkdir -p ares-deps/share/libretro/shaders/shaders_slang
   cp -R build_temp/slang-shaders/. ares-deps/share/libretro/shaders/shaders_slang/
+  echo "[slang_shaders] installing -- success"
 }

--- a/deps.linux/slang_shaders
+++ b/deps.linux/slang_shaders
@@ -17,10 +17,6 @@ slang_shaders_package_source() {
   echo "[slang_shaders] packaging source -- skipped"
 }
 
-slang_shaders_clean() {
-  echo "[slang_shaders] cleaning up -- skipped"
-}
-
 slang_shaders_patch() {
   echo "[slang_shaders] patching -- skipped"
 }

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -43,8 +43,8 @@ librashader_build() {
   echo "[librashader] building"
   cd librashader
   export RUSTFLAGS=-g
-  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target x86_64-apple-darwin
-  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-apple-darwin
+  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target x86_64-apple-darwin -- --features=stable
+  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-apple-darwin -- --features=stable
   lipo -create -output target/${librashader_profile}/librashader.dylib target/x86_64-apple-darwin/${librashader_profile}/librashader.dylib target/aarch64-apple-darwin/${librashader_profile}/librashader.dylib
   # Package debug symbols
   mkdir -p target/${librashader_profile}/librashader.dylib.dSYM

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -1,23 +1,10 @@
 librashader_name='librashader'
 librashader_version='0.9.1'
 librashader_url='https://github.com/SnowflakePowered/librashader.git'
-librashader_hash='ad661b661c3d10cb4a2573a78a41857330d499ca'
-librashader_profile='release'
 
 librashader_setup() {
   echo "[librashader] cloning"
-  if [ ! -d "librashader" ]; then
-    git clone https://github.com/SnowflakePowered/librashader.git
-  else
-    git -C librashader fetch
-  fi
-  git -C librashader reset --hard "$librashader_hash"
-  
-  if [[ $config == "Debug" ]]; then
-    librashader_profile='debug'
-  elif [[ $config == "Release" ]]; then
-    librashader_profile='optimized'
-  fi
+  git clone --branch librashader-v${librashader_version} --depth 1 ${librashader_url}
   export MACOSX_DEPLOYMENT_TARGET=10.15
   echo "[librashader] cloning -- success"
 }
@@ -29,29 +16,17 @@ librashader_package_source() {
 }
 
 librashader_patch() {
-  echo "[librashader] patching source"
-  cd librashader
-  echo "Pinning nightly Rust version to 2025-03-21"
-  echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
-  echo $'targets = [ \"x86_64-apple-darwin\", \"aarch64-apple-darwin\" ]' >> rust-toolchain.toml
-  cd ..
-  echo "[librashader] patching source -- success"
+  echo "[librashader] patching -- skipped"
 }
 
 librashader_build() {
   echo "[librashader] building"
   cd librashader
-  export RUSTFLAGS=-g
-  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target x86_64-apple-darwin
-  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-apple-darwin
-  lipo -create -output target/${librashader_profile}/librashader.dylib target/x86_64-apple-darwin/${librashader_profile}/librashader.dylib target/aarch64-apple-darwin/${librashader_profile}/librashader.dylib
-  # Package debug symbols
-  mkdir -p target/${librashader_profile}/librashader.dylib.dSYM
-  mkdir -p target/${librashader_profile}/librashader.dylib.dSYM/Contents/Resources/DWARF
-  ditto target/*-apple-darwin/${librashader_profile}/deps/liblibrashader_capi.dylib.dSYM/Contents/Resources/Relocations target/${librashader_profile}/librashader.dylib.dSYM/Contents/Resources/Relocations
-  ditto target/aarch64-apple-darwin/${librashader_profile}/deps/liblibrashader_capi.dylib.dSYM/Contents/Info.plist target/${librashader_profile}/librashader.dylib.dSYM/Contents/Info.plist
-  lipo -create -output target/${librashader_profile}/librashader.dylib.dSYM/Contents/Resources/DWARF/liblibrashader_capi.dylib target/x86_64-apple-darwin/${librashader_profile}/deps/liblibrashader_capi.dylib.dSYM/Contents/Resources/DWARF/liblibrashader_capi.dylib target/aarch64-apple-darwin/${librashader_profile}/deps/liblibrashader_capi.dylib.dSYM/Contents/Resources/DWARF/liblibrashader_capi.dylib
+  cargo build --release -p librashader-capi --features=stable --target x86_64-apple-darwin
+  cargo build --release -p librashader-capi --features=stable --target aarch64-apple-darwin
+  lipo -create -output target/release/librashader.dylib \
+    target/x86_64-apple-darwin/release/liblibrashader_capi.dylib \
+    target/aarch64-apple-darwin/release/liblibrashader_capi.dylib
   cd ..
   echo "[librashader] building -- success"
 }
@@ -59,8 +34,7 @@ librashader_build() {
 librashader_install() {
   echo "[librashader] installing"
   ditto build_temp/librashader/include ares-deps/include/librashader/
-  ditto build_temp/librashader/target/${librashader_profile}/librashader.dylib ares-deps/lib/librashader.dylib
-  ditto build_temp/librashader/target/${librashader_profile}/librashader.dylib.dSYM ares-deps/lib/librashader.dylib.dSYM
+  ditto build_temp/librashader/target/release/librashader.dylib ares-deps/lib/librashader.dylib
   fix_rpaths ares-deps/lib/librashader.dylib
   ditto build_temp/librashader/LICENSE.md ares-deps/licenses/librashader/LICENSE.md
   ditto build_temp/librashader/LICENSE-GPL.md ares-deps/licenses/librashader/LICENSE-GPL.md

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -31,9 +31,9 @@ librashader_package_source() {
 librashader_patch() {
   echo "[librashader] patching source"
   cd librashader
-  echo "Pinning Rust to stable 1.93.0"
+  echo "Pinning nightly Rust version to 2025-03-21"
   echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"1.93.0\"' >> rust-toolchain.toml
+  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
   echo $'targets = [ \"x86_64-apple-darwin\", \"aarch64-apple-darwin\" ]' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"
@@ -43,8 +43,8 @@ librashader_build() {
   echo "[librashader] building"
   cd librashader
   export RUSTFLAGS=-g
-  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target x86_64-apple-darwin -- --features=stable
-  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-apple-darwin -- --features=stable
+  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target x86_64-apple-darwin
+  cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-apple-darwin
   lipo -create -output target/${librashader_profile}/librashader.dylib target/x86_64-apple-darwin/${librashader_profile}/librashader.dylib target/aarch64-apple-darwin/${librashader_profile}/librashader.dylib
   # Package debug symbols
   mkdir -p target/${librashader_profile}/librashader.dylib.dSYM

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -28,16 +28,12 @@ librashader_package_source() {
   echo "[librashader] packaging source -- success"
 }
 
-librashader_clean() {
-  echo "[librashader] cleaning up -- skipped"
-}
-
 librashader_patch() {
   echo "[librashader] patching source"
   cd librashader
-  echo "Pinning nightly Rust version to 2025-05-20"
+  echo "Pinning Rust to stable 1.93.0"
   echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
+  echo $'channel = \"1.93.0\"' >> rust-toolchain.toml
   echo $'targets = [ \"x86_64-apple-darwin\", \"aarch64-apple-darwin\" ]' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"

--- a/deps.macos/moltenvk
+++ b/deps.macos/moltenvk
@@ -21,10 +21,6 @@ moltenvk_package_source() {
   echo "[MoltenVK] packaging source -- success"
 }
 
-moltenvk_clean() {
-  echo "[MoltenVK] cleaning up -- skipped"
-}
-
 moltenvk_patch() {
   echo "[MoltenVK] patching source -- skipped"
 }
@@ -40,6 +36,8 @@ moltenvk_build() {
 
 moltenvk_install() {
   echo "[MoltenVK] installing"
+  mkdir -p ares-deps/lib
+  mkdir -p ares-deps/licenses/MoltenVK
   ditto build_temp/MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib ares-deps/lib/libMoltenVK.dylib
   ditto build_temp/MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib.dSYM ares-deps/lib/libMoltenVK.dylib.dSYM
   ditto build_temp/MoltenVK/LICENSE ares-deps/licenses/MoltenVK/LICENSE

--- a/deps.macos/moltenvk
+++ b/deps.macos/moltenvk
@@ -1,45 +1,31 @@
 moltenvk_name='MoltenVK'
 moltenvk_version='1.4.1'
-moltenvk_url='https://github.com/KhronosGroup/MoltenVK.git'
-moltenvk_hash='db445ff2042d9ce348c439ad8451112f354b8d2a'
 
 moltenvk_setup() {
-  echo "[MoltenVK] cloning"
-  if [ ! -d "MoltenVK" ]; then
-    git clone https://github.com/KhronosGroup/MoltenVK.git
-  else
-    git -C MoltenVK fetch
-  fi
-  git -C MoltenVK reset --hard "$moltenvk_hash"
-  export MACOSX_DEPLOYMENT_TARGET=10.15
-  echo "[MoltenVK] cloning -- success"
+  echo "[MoltenVK] downloading pre-built package"
+  curl -sL -o MoltenVK-macos.tar "https://github.com/KhronosGroup/MoltenVK/releases/download/v${moltenvk_version}/MoltenVK-macos.tar"
+  tar xf MoltenVK-macos.tar
+  rm MoltenVK-macos.tar
+  echo "[MoltenVK] downloading -- success"
 }
 
 moltenvk_package_source() {
-  echo "[MoltenVK] packaging source"
-  ditto MoltenVK/ ../ares-deps-source/src/MoltenVK
-  echo "[MoltenVK] packaging source -- success"
+  echo "[MoltenVK] packaging source -- skipped (pre-built)"
 }
 
 moltenvk_patch() {
-  echo "[MoltenVK] patching source -- skipped"
+  echo "[MoltenVK] patching -- skipped"
 }
 
 moltenvk_build() {
-  echo "[MoltenVK] building"
-  cd MoltenVK
-  ./fetchDependencies --macos
-  xcodebuild build -quiet -project MoltenVKPackaging.xcodeproj -scheme "MoltenVK Package (macOS only)" -configuration ${config} GCC_GENERATE_DEBUGGING_SYMBOLS=TRUE DEBUG_INFORMATION_FORMAT="dwarf-with-dsym" GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS MVK_LOG_LEVEL_INFO=0 MVK_LOG_LEVEL_DEBUG=0'
-  cd ..
-  echo "[MoltenVK] building -- success"
+  echo "[MoltenVK] building -- skipped (pre-built)"
 }
 
 moltenvk_install() {
   echo "[MoltenVK] installing"
   mkdir -p ares-deps/lib
   mkdir -p ares-deps/licenses/MoltenVK
-  ditto build_temp/MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib ares-deps/lib/libMoltenVK.dylib
-  ditto build_temp/MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib.dSYM ares-deps/lib/libMoltenVK.dylib.dSYM
+  ditto build_temp/MoltenVK/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib ares-deps/lib/libMoltenVK.dylib
   ditto build_temp/MoltenVK/LICENSE ares-deps/licenses/MoltenVK/LICENSE
   echo "[MoltenVK] installing -- success"
 }

--- a/deps.macos/moltenvk
+++ b/deps.macos/moltenvk
@@ -1,9 +1,10 @@
 moltenvk_name='MoltenVK'
 moltenvk_version='1.4.1'
+moltenvk_url='https://github.com/KhronosGroup/MoltenVK.git'
 
 moltenvk_setup() {
   echo "[MoltenVK] downloading pre-built package"
-  curl -sL -o MoltenVK-macos.tar "https://github.com/KhronosGroup/MoltenVK/releases/download/v${moltenvk_version}/MoltenVK-macos.tar"
+  curl -sL -o MoltenVK-macos.tar "${moltenvk_url%.git}/releases/download/v${moltenvk_version}/MoltenVK-macos.tar"
   tar xf MoltenVK-macos.tar
   rm MoltenVK-macos.tar
   echo "[MoltenVK] downloading -- success"

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -4,11 +4,15 @@ sdl_version='3.4.0'
 sdl_setup() {
   echo "[SDL3] downloading pre-built package"
   curl -sL -o SDL3.dmg "https://github.com/libsdl-org/SDL/releases/download/release-${sdl_version}/SDL3-${sdl_version}.dmg"
-  hdiutil attach SDL3.dmg -mountpoint /tmp/SDL3_mount -quiet
+  hdiutil attach SDL3.dmg -noverify -nobrowse
+  # Find the mount point (volume name may vary)
+  local mount_point=$(hdiutil info | grep -A1 "SDL3" | grep "/Volumes/" | awk '{print $1}')
+  echo "SDL3 DMG mounted at: ${mount_point}"
+  ls "${mount_point}/"
   mkdir -p SDL
-  ditto /tmp/SDL3_mount/SDL3/SDL3.xcframework/macos-arm64_x86_64/SDL3.framework SDL/SDL3.framework
-  ditto /tmp/SDL3_mount/SDL3/LICENSE.txt SDL/LICENSE.txt
-  hdiutil detach /tmp/SDL3_mount -quiet
+  ditto "${mount_point}/SDL3.xcframework/macos-arm64_x86_64/SDL3.framework" SDL/SDL3.framework
+  ditto "${mount_point}/LICENSE.txt" SDL/LICENSE.txt
+  hdiutil detach "${mount_point}"
   rm SDL3.dmg
   echo "[SDL3] downloading -- success"
 }

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -23,10 +23,6 @@ sdl_package_source() {
   echo "[SDL3] packaging source -- success"
 }
 
-sdl_clean() {
-  echo "[SDL3] cleaning up -- skipped"
-}
-
 sdl_patch() {
   echo "[SDL3] patching -- skipped"
 }

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -4,11 +4,8 @@ sdl_version='3.4.0'
 sdl_setup() {
   echo "[SDL3] downloading pre-built package"
   curl -sL -o SDL3.dmg "https://github.com/libsdl-org/SDL/releases/download/release-${sdl_version}/SDL3-${sdl_version}.dmg"
-  hdiutil attach SDL3.dmg -noverify -nobrowse
-  # Find the mount point (volume name may vary)
-  local mount_point=$(hdiutil info | grep -A1 "SDL3" | grep "/Volumes/" | awk '{print $1}')
+  local mount_point=$(hdiutil attach SDL3.dmg -noverify -nobrowse | grep "/Volumes/" | sed 's|.*\(/Volumes/.*\)|\1|')
   echo "SDL3 DMG mounted at: ${mount_point}"
-  ls "${mount_point}/"
   mkdir -p SDL
   ditto "${mount_point}/SDL3.xcframework/macos-arm64_x86_64/SDL3.framework" SDL/SDL3.framework
   ditto "${mount_point}/LICENSE.txt" SDL/LICENSE.txt

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -1,26 +1,19 @@
 sdl_name='SDL3'
 sdl_version='3.4.0'
-sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='a962f40bbba175e9716557a25d5d7965f134a3d3'
-SDLARGS=()
 
-## Build Steps
 sdl_setup() {
-  echo "[SDL3] cloning"
-  if [ ! -d "SDL" ]; then
-    git clone ${sdl_url}
-  else
-    git -C SDL fetch
-  fi
-  git -C SDL reset --hard "$sdl_hash"
-  export MACOSX_DEPLOYMENT_TARGET=10.15
-  echo "[SDL3] cloning -- success"
+  echo "[SDL3] downloading pre-built package"
+  curl -sL -o SDL3.dmg "https://github.com/libsdl-org/SDL/releases/download/release-${sdl_version}/SDL3-${sdl_version}.dmg"
+  hdiutil attach SDL3.dmg -mountpoint SDL3_mount -quiet
+  ditto SDL3_mount/SDL3/SDL3.xcframework/macos-arm64_x86_64/SDL3.framework SDL/SDL3.framework
+  ditto SDL3_mount/SDL3/LICENSE.txt SDL/LICENSE.txt
+  hdiutil detach SDL3_mount -quiet
+  rm SDL3.dmg
+  echo "[SDL3] downloading -- success"
 }
 
 sdl_package_source() {
-  echo "[SDL3] packaging source"
-  ditto SDL ../ares-deps-source/src/SDL
-  echo "[SDL3] packaging source -- success"
+  echo "[SDL3] packaging source -- skipped (pre-built)"
 }
 
 sdl_patch() {
@@ -28,33 +21,12 @@ sdl_patch() {
 }
 
 sdl_build() {
-  echo "[SDL3] building"
-  SDLARGS=()
-  SDLARGS+=("-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64;")
-  
-  cd SDL
-  
-  xcodebuild build -project ./Xcode/SDL/SDL.xcodeproj \
-                   -scheme "SDL3" \
-                   archive \
-                   -configuration $config \
-                   DEBUG_INFORMATION_FORMAT="dwarf-with-dsym" \
-                   -archivePath "$SCRIPT_DIR/build_temp/SDL/build" \
-                   ARCHS="x86_64 arm64" \
-                   ONLY_ACTIVE_ARCH=FALSE \
-                   2>&1 | xcbeautify --renderer github-actions
-
-  cd ..
-  echo "[SDL3] building -- success"
+  echo "[SDL3] building -- skipped (pre-built)"
 }
 
 sdl_install() {
   echo "[SDL3] installing"
-  ditto build_temp/SDL/build.xcarchive/Products/Library/Frameworks/SDL3.framework ares-deps/lib/SDL3.framework
-  ditto build_temp/SDL/build.xcarchive/dSYMs/SDL3.framework.dSYM ares-deps/lib/SDL3.framework.dSYM
+  ditto build_temp/SDL/SDL3.framework ares-deps/lib/SDL3.framework
   ditto build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL/LICENSE.txt
   echo "[SDL3] installing -- success"
 }
-
-
-

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -4,10 +4,11 @@ sdl_version='3.4.0'
 sdl_setup() {
   echo "[SDL3] downloading pre-built package"
   curl -sL -o SDL3.dmg "https://github.com/libsdl-org/SDL/releases/download/release-${sdl_version}/SDL3-${sdl_version}.dmg"
-  hdiutil attach SDL3.dmg -mountpoint SDL3_mount -quiet
-  ditto SDL3_mount/SDL3/SDL3.xcframework/macos-arm64_x86_64/SDL3.framework SDL/SDL3.framework
-  ditto SDL3_mount/SDL3/LICENSE.txt SDL/LICENSE.txt
-  hdiutil detach SDL3_mount -quiet
+  hdiutil attach SDL3.dmg -mountpoint /tmp/SDL3_mount -quiet
+  mkdir -p SDL
+  ditto /tmp/SDL3_mount/SDL3/SDL3.xcframework/macos-arm64_x86_64/SDL3.framework SDL/SDL3.framework
+  ditto /tmp/SDL3_mount/SDL3/LICENSE.txt SDL/LICENSE.txt
+  hdiutil detach /tmp/SDL3_mount -quiet
   rm SDL3.dmg
   echo "[SDL3] downloading -- success"
 }

--- a/deps.macos/slang_shaders
+++ b/deps.macos/slang_shaders
@@ -19,29 +19,25 @@ slang_shaders_package_source() {
   echo "[slang_shaders] packaging source -- skipped"
 }
 
-slang_shaders_clean() {
-  echo "[slang_shaders] cleaning up -- skipped"
-}
-
 slang_shaders_patch() {
   echo "[slang_shaders] patching -- skipped"
 }
 
 slang_shaders_build() {
-  echo "[slang_shaders] building"
+  echo "[slang_shaders] cleaning source tree"
   cd slang-shaders
   rm -rf .git
   rm -f .gitlab-ci.yml
   rm -f configure
   rm -f Makefile
   cd ..
-  echo "[slang_shaders] building -- skipped"
+  echo "[slang_shaders] cleaning source tree -- success"
 }
 
 slang_shaders_install() {
   echo "[slang_shaders] installing"
   ditto "build_temp"/slang-shaders ares-deps/share/libretro/shaders/shaders_slang
-  echo "[slang_shaders] installing -- skipped"
+  echo "[slang_shaders] installing -- success"
 }
 
 

--- a/deps.macos/slang_shaders
+++ b/deps.macos/slang_shaders
@@ -3,15 +3,11 @@ slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
 slang_shaders_hash='46dcd51d14efd2d49505d932d6b979f141f538d8'
 
-## Build Steps
 slang_shaders_setup() {
   echo "[slang_shaders] cloning"
-  if [ ! -d "slang-shaders" ]; then
-    git clone https://github.com/libretro/slang-shaders.git
-  else
-    git -C slang-shaders fetch
-  fi
-  git -C slang-shaders reset --hard "$slang_shaders_hash"
+  git clone --depth 1 ${slang_shaders_url}
+  git -C slang-shaders fetch --depth 1 origin ${slang_shaders_hash}
+  git -C slang-shaders checkout ${slang_shaders_hash}
   echo "[slang_shaders] cloning -- success"
 }
 
@@ -27,18 +23,13 @@ slang_shaders_build() {
   echo "[slang_shaders] cleaning source tree"
   cd slang-shaders
   rm -rf .git
-  rm -f .gitlab-ci.yml
-  rm -f configure
-  rm -f Makefile
+  rm -f .gitlab-ci.yml configure Makefile
   cd ..
   echo "[slang_shaders] cleaning source tree -- success"
 }
 
 slang_shaders_install() {
   echo "[slang_shaders] installing"
-  ditto "build_temp"/slang-shaders ares-deps/share/libretro/shaders/shaders_slang
+  ditto build_temp/slang-shaders ares-deps/share/libretro/shaders/shaders_slang
   echo "[slang_shaders] installing -- success"
 }
-
-
-

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -1,23 +1,10 @@
 librashader_name='librashader'
 librashader_version='0.9.1'
 librashader_url='https://github.com/SnowflakePowered/librashader.git'
-librashader_hash='ad661b661c3d10cb4a2573a78a41857330d499ca'
-librashader_profile='release'
 
 librashader_setup() {
   echo "[librashader] cloning"
-  if [ ! -d "librashader" ]; then
-    git clone https://github.com/SnowflakePowered/librashader.git
-  else
-    git -C librashader fetch
-  fi
-  git -C librashader reset --hard "$librashader_hash"
-  
-  if [[ $config == "Debug" ]]; then
-    librashader_profile='debug'
-  elif [[ $config == "Release" ]]; then
-    librashader_profile='optimized'
-  fi
+  git clone --branch librashader-v${librashader_version} --depth 1 ${librashader_url}
   echo "[librashader] cloning -- success"
 }
 
@@ -29,14 +16,7 @@ librashader_package_source() {
 }
 
 librashader_patch() {
-  echo "[librashader] patching source"
-  cd librashader
-  echo "Pinning nightly Rust version to 2025-03-21"
-  echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
-  echo $'targets = [ \"aarch64-pc-windows-msvc\", \"x86_64-pc-windows-msvc\" ]' >> rust-toolchain.toml
-  cd ..
-  echo "[librashader] patching source -- success"
+  echo "[librashader] patching -- skipped"
 }
 
 librashader_build() {
@@ -47,9 +27,9 @@ librashader_build() {
   export CFLAGS='-MT'
   if [[ $envName = windows-arm64 ]]; then
     echo "Targeting aarch64..."
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc -- --no-default-features --features=runtime-opengl
+    cargo build --release -p librashader-capi --target aarch64-pc-windows-msvc --no-default-features --features=runtime-opengl,stable
   else
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --no-default-features --features=runtime-opengl
+    cargo build --release -p librashader-capi --no-default-features --features=runtime-opengl,stable
   fi
   unset RUSTFLAGS CXXFLAGS CFLAGS
   cd ..
@@ -61,16 +41,16 @@ librashader_install() {
   mkdir -p ares-deps/include/librashader/
   mkdir -p ares-deps/lib/
   cp -R build_temp/librashader/include/. ares-deps/include/librashader/
+
   if [[ $envName = windows-arm64 ]]; then
-    local targetDir="build_temp/librashader/target/aarch64-pc-windows-msvc/${librashader_profile}"
+    local targetDir="build_temp/librashader/target/aarch64-pc-windows-msvc/release"
   else
-    local targetDir="build_temp/librashader/target/${librashader_profile}"
+    local targetDir="build_temp/librashader/target/release"
   fi
-  cp -R ${targetDir}/librashader.d ares-deps/lib/librashader.d
-  cp -R ${targetDir}/librashader.dll ares-deps/lib/librashader.dll
-  cp -R ${targetDir}/librashader.dll.exp ares-deps/lib/librashader.dll.exp
-  cp -R ${targetDir}/librashader.dll.lib ares-deps/lib/librashader.dll.lib
-  mv ares-deps/lib/librashader.dll.lib ares-deps/lib/librashader.lib
-  cp -R ${targetDir}/librashader.pdb ares-deps/lib/librashader.pdb
+
+  cp ${targetDir}/librashader_capi.dll ares-deps/lib/librashader.dll
+  cp ${targetDir}/librashader_capi.dll.lib ares-deps/lib/librashader.lib
+  cp ${targetDir}/librashader_capi.pdb ares-deps/lib/librashader.pdb
+
   echo "[librashader] installing -- success"
 }

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -31,9 +31,9 @@ librashader_package_source() {
 librashader_patch() {
   echo "[librashader] patching source"
   cd librashader
-  echo "Pinning Rust to stable 1.93.0"
+  echo "Pinning nightly Rust version to 2025-03-21"
   echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"1.93.0\"' >> rust-toolchain.toml
+  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
   echo $'targets = [ \"aarch64-pc-windows-msvc\", \"x86_64-pc-windows-msvc\" ]' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"
@@ -47,9 +47,9 @@ librashader_build() {
   export CFLAGS='-MT'
   if [[ $envName = windows-arm64 ]]; then
     echo "Targeting aarch64..."
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc -- --no-default-features --features=runtime-opengl,stable
+    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc -- --no-default-features --features=runtime-opengl
   else
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --no-default-features --features=runtime-opengl,stable
+    cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --no-default-features --features=runtime-opengl
   fi
   unset RUSTFLAGS CXXFLAGS CFLAGS
   cd ..

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -47,9 +47,9 @@ librashader_build() {
   export CFLAGS='-MT'
   if [[ $envName = windows-arm64 ]]; then
     echo "Targeting aarch64..."
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc -- --no-default-features --features=runtime-opengl
+    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc -- --no-default-features --features=runtime-opengl,stable
   else
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --no-default-features --features=runtime-opengl
+    cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --no-default-features --features=runtime-opengl,stable
   fi
   unset RUSTFLAGS CXXFLAGS CFLAGS
   cd ..

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -28,16 +28,12 @@ librashader_package_source() {
   echo "[librashader] packaging source -- success"
 }
 
-librashader_clean() {
-  echo "[librashader] cleaning up -- skipped"
-}
-
 librashader_patch() {
   echo "[librashader] patching source"
   cd librashader
-  echo "Pinning nightly Rust version to 2025-05-20"
+  echo "Pinning Rust to stable 1.93.0"
   echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
+  echo $'channel = \"1.93.0\"' >> rust-toolchain.toml
   echo $'targets = [ \"aarch64-pc-windows-msvc\", \"x86_64-pc-windows-msvc\" ]' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"
@@ -66,15 +62,15 @@ librashader_install() {
   mkdir -p ares-deps/lib/
   cp -R build_temp/librashader/include/. ares-deps/include/librashader/
   if [[ $envName = windows-arm64 ]]; then
-    local targetName="aarch64-pc-windows-msvc"
+    local targetDir="build_temp/librashader/target/aarch64-pc-windows-msvc/${librashader_profile}"
   else
-    local targetName=""
+    local targetDir="build_temp/librashader/target/${librashader_profile}"
   fi
-  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.d ares-deps/lib/librashader.d
-  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.dll ares-deps/lib/librashader.dll
-  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.dll.exp ares-deps/lib/librashader.dll.exp
-  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.dll.lib ares-deps/lib/librashader.dll.lib
+  cp -R ${targetDir}/librashader.d ares-deps/lib/librashader.d
+  cp -R ${targetDir}/librashader.dll ares-deps/lib/librashader.dll
+  cp -R ${targetDir}/librashader.dll.exp ares-deps/lib/librashader.dll.exp
+  cp -R ${targetDir}/librashader.dll.lib ares-deps/lib/librashader.dll.lib
   mv ares-deps/lib/librashader.dll.lib ares-deps/lib/librashader.lib
-  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.pdb ares-deps/lib/librashader.pdb
+  cp -R ${targetDir}/librashader.pdb ares-deps/lib/librashader.pdb
   echo "[librashader] installing -- success"
 }

--- a/deps.windows/sdl
+++ b/deps.windows/sdl
@@ -23,10 +23,6 @@ sdl_package_source() {
   echo "[SDL3] packaging source -- success"
 }
 
-sdl_clean() {
-  echo "[SDL3] cleaning up -- skipped"
-}
-
 sdl_patch() {
   echo "[SDL3] patching -- skipped"
 }

--- a/deps.windows/sdl
+++ b/deps.windows/sdl
@@ -1,26 +1,16 @@
 sdl_name='SDL3'
 sdl_version='3.4.0'
-sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='a962f40bbba175e9716557a25d5d7965f134a3d3'
-SDLARGS=("-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded")
 
-## Build Steps
 sdl_setup() {
-  echo "[SDL3] cloning"
-  if [ ! -d "SDL" ]; then
-    git clone ${sdl_url}
-  else
-    git -C SDL fetch
-  fi
-  git -C SDL reset --hard "$sdl_hash"
-  echo "[SDL3] cloning -- success"
+  echo "[SDL3] downloading pre-built package"
+  curl -sL -o SDL3-devel.zip "https://github.com/libsdl-org/SDL/releases/download/release-${sdl_version}/SDL3-devel-${sdl_version}-VC.zip"
+  unzip -q SDL3-devel.zip
+  mv SDL3-${sdl_version} SDL
+  echo "[SDL3] downloading -- success"
 }
 
 sdl_package_source() {
-  echo "[SDL3] packaging source"
-  mkdir -p ../ares-deps-source/src/SDL/
-  cp -R SDL/. ../ares-deps-source/src/SDL
-  echo "[SDL3] packaging source -- success"
+  echo "[SDL3] packaging source -- skipped (pre-built)"
 }
 
 sdl_patch() {
@@ -28,25 +18,7 @@ sdl_patch() {
 }
 
 sdl_build() {
-  echo "[SDL3] building"
-  if [[ $envName = windows-arm64 ]]; then
-    SDLARGS+=("-A ARM64")
-  else
-    SDLARGS+=("-A x64")
-  fi
-
-  cd SDL
-  mkdir -p build
-  pushd build
-
-  echo ${config}
-
-  cmake .. "${SDLARGS[@]}" -G "Visual Studio 17 2022"
-  cmake --build . --config ${config}
-
-  popd
-  cd ..
-  echo "[SDL3] building -- success"
+  echo "[SDL3] building -- skipped (pre-built)"
 }
 
 sdl_install() {
@@ -54,16 +26,18 @@ sdl_install() {
   mkdir -p ares-deps/lib
   mkdir -p ares-deps/include/SDL3
   mkdir -p ares-deps/licenses/SDL3
-  cp -R build_temp/SDL/build/${config}/SDL3.dll ares-deps/lib/SDL3.dll
-  cp -R build_temp/SDL/build/${config}/SDL3.pdb ares-deps/lib/SDL3.pdb
-  cp -R build_temp/SDL/build/${config}/SDL3.exp ares-deps/lib/SDL3.exp
-  cp -R build_temp/SDL/build/${config}/SDL3.lib ares-deps/lib/SDL3.lib
-  mkdir -p ares-deps/include/SDL3
+
+  if [[ $envName = windows-arm64 ]]; then
+    local arch="arm64"
+  else
+    local arch="x64"
+  fi
+
+  cp build_temp/SDL/lib/${arch}/SDL3.dll ares-deps/lib/SDL3.dll
+  cp build_temp/SDL/lib/${arch}/SDL3.lib ares-deps/lib/SDL3.lib
+  cp build_temp/SDL/lib/${arch}/SDL3.pdb ares-deps/lib/SDL3.pdb
   cp -R build_temp/SDL/include/SDL3/. ares-deps/include/SDL3/
-  cp -R build_temp/SDL/build/include-config-${config}/build_config/. ares-deps/include/SDL3/
-  cp -R build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL3/LICENSE.txt
+  cp build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL3/LICENSE.txt
+
   echo "[SDL3] installing -- success"
 }
-
-
-

--- a/deps.windows/slang_shaders
+++ b/deps.windows/slang_shaders
@@ -3,15 +3,11 @@ slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
 slang_shaders_hash='46dcd51d14efd2d49505d932d6b979f141f538d8'
 
-## Build Steps
 slang_shaders_setup() {
   echo "[slang_shaders] cloning"
-  if [ ! -d "slang-shaders" ]; then
-    git clone https://github.com/libretro/slang-shaders.git
-  else
-    git -C slang-shaders fetch
-  fi
-  git -C slang-shaders reset --hard "$slang_shaders_hash"
+  git clone --depth 1 ${slang_shaders_url}
+  git -C slang-shaders fetch --depth 1 origin ${slang_shaders_hash}
+  git -C slang-shaders checkout ${slang_shaders_hash}
   echo "[slang_shaders] cloning -- success"
 }
 
@@ -27,9 +23,7 @@ slang_shaders_build() {
   echo "[slang_shaders] cleaning source tree"
   cd slang-shaders
   rm -rf .git
-  rm -f .gitlab-ci.yml
-  rm -f configure
-  rm -f Makefile
+  rm -f .gitlab-ci.yml configure Makefile
   cd ..
   echo "[slang_shaders] cleaning source tree -- success"
 }
@@ -40,7 +34,3 @@ slang_shaders_install() {
   cp -R build_temp/slang-shaders/. ares-deps/share/libretro/shaders/shaders_slang/
   echo "[slang_shaders] installing -- success"
 }
-
-
-
-

--- a/deps.windows/slang_shaders
+++ b/deps.windows/slang_shaders
@@ -19,30 +19,26 @@ slang_shaders_package_source() {
   echo "[slang_shaders] packaging source -- skipped"
 }
 
-slang_shaders_clean() {
-  echo "[slang_shaders] cleaning up -- skipped"
-}
-
 slang_shaders_patch() {
   echo "[slang_shaders] patching -- skipped"
 }
 
 slang_shaders_build() {
-  echo "[slang_shaders] building"
+  echo "[slang_shaders] cleaning source tree"
   cd slang-shaders
   rm -rf .git
   rm -f .gitlab-ci.yml
   rm -f configure
   rm -f Makefile
   cd ..
-  echo "[slang_shaders] building -- skipped"
+  echo "[slang_shaders] cleaning source tree -- success"
 }
 
 slang_shaders_install() {
   echo "[slang_shaders] installing"
   mkdir -p ares-deps/share/libretro/shaders/shaders_slang
   cp -R build_temp/slang-shaders/. ares-deps/share/libretro/shaders/shaders_slang/
-  echo "[slang_shaders] installing -- skipped"
+  echo "[slang_shaders] installing -- success"
 }
 
 


### PR DESCRIPTION
## Summary

Complete rewrite of the README to document the entire ares-deps build system as it stands after the recent optimization work.

### What changed in the build system (already merged to main)

**Build time improvements:**
| Platform | Before | After |
|---|---|---|
| macOS universal | ~31 min | ~7 min 30s |
| Windows x64 | ~12 min | ~5 min 42s |
| Windows arm64 | ~12 min | ~5 min 53s |
| Linux x64 | ~6 min 40s | ~5 min 02s |
| Linux arm64 | ~5 min | ~3 min 53s |

**Key optimizations:**
- **SDL3** (Windows/macOS): switched from compiling from source to downloading official pre-built packages (`SDL3-devel-*-VC.zip` for Windows, `SDL3-*.dmg` for macOS)
- **MoltenVK** (macOS): switched from compiling from source (~15 min) to downloading official pre-built `MoltenVK-macos.tar`
- **librashader** (all platforms): simplified build from complex build-script + cbindgen + nightly Rust to direct `cargo build --release -p librashader-capi --features=stable` on Rust stable, using pre-generated headers from the repo
- **slang-shaders**: optimized git cloning with `--depth 1`
- **Rust toolchain**: switched from nightly to stable across all platforms
- **deps.json**: automatically generated during releases with all dependency versions, upstream URLs, git tags, and SHA256 hashes for all 5 platforms

### What this PR adds

A comprehensive README covering:
- Dependency table with versions, sources and build strategies
- Platform matrix showing what's compiled vs pre-built per OS
- Local build instructions and prerequisites
- Build lifecycle architecture (`_setup`, `_patch`, `_package_source`, `_build`, `_install`)
- Output directory structure
- CI/CD workflow documentation (build matrix + release pipeline)
- `deps.json` format specification with field descriptions
- Instructions for creating releases and updating dependencies

## Test plan

- [x] All 5 platform builds pass on CI
- [x] Release workflow generates correct `deps.json` with all platforms and dependencies
- [x] ares-snap successfully consumes the new deps.json format and builds
- [ ] Review README renders correctly on GitHub