### PR TITLE
deps.windows/librashader: Add runtime-d3d12 feature

### DIFF
--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -51,9 +51,9 @@ librashader_build() {
   export CFLAGS='-MT'
   if [[ $envName = windows-arm64 ]]; then
     echo "Targeting aarch64..."
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc -- --no-default-features --features=runtime-opengl
+    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc -- --no-default-features --features=runtime-opengl,runtime-d3d12
   else
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --no-default-features --features=runtime-opengl
+    cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --no-default-features --features=runtime-opengl,runtime-d3d12
   fi
   unset RUSTFLAGS CXXFLAGS CFLAGS
   cd ..


### PR DESCRIPTION
Adds `runtime-d3d12` to the cargo run of librashader for upcoming Direct3D 12 display backend.