### PR TITLE
Update dependencies (post-v147-update-2)

### DIFF
--- a/deps.linux/slang_shaders
+++ b/deps.linux/slang_shaders
@@ -1,7 +1,7 @@
 slang_shaders_name='slang-shaders'
 slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
-slang_shaders_hash='46dcd51d14efd2d49505d932d6b979f141f538d8'
+slang_shaders_hash='d0cbcd0ae6306231df799dc02d753a4c21d9a3d5'
 
 ## Build Steps
 slang_shaders_setup() {

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -1,7 +1,7 @@
 librashader_name='librashader'
-librashader_version='0.9.1'
+librashader_version='0.10.1'
 librashader_url='https://github.com/SnowflakePowered/librashader.git'
-librashader_hash='ad661b661c3d10cb4a2573a78a41857330d499ca'
+librashader_hash='a910bee8d2ead0acf2f83b3e5ad0b8f8f66b53db'
 librashader_profile='release'
 
 librashader_setup() {

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -1,7 +1,7 @@
 sdl_name='SDL3'
-sdl_version='3.4.0'
+sdl_version='3.4.4'
 sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='a962f40bbba175e9716557a25d5d7965f134a3d3'
+sdl_hash='5848e584a1b606de26e3dbd1c7e4ecbc34f807a6'
 SDLARGS=()
 
 ## Build Steps

--- a/deps.macos/slang_shaders
+++ b/deps.macos/slang_shaders
@@ -1,7 +1,7 @@
 slang_shaders_name='slang-shaders'
 slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
-slang_shaders_hash='46dcd51d14efd2d49505d932d6b979f141f538d8'
+slang_shaders_hash='d0cbcd0ae6306231df799dc02d753a4c21d9a3d5'
 
 ## Build Steps
 slang_shaders_setup() {

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -1,7 +1,7 @@
 librashader_name='librashader'
-librashader_version='0.9.1'
+librashader_version='0.10.1'
 librashader_url='https://github.com/SnowflakePowered/librashader.git'
-librashader_hash='ad661b661c3d10cb4a2573a78a41857330d499ca'
+librashader_hash='a910bee8d2ead0acf2f83b3e5ad0b8f8f66b53db'
 librashader_profile='release'
 
 librashader_setup() {
@@ -51,9 +51,9 @@ librashader_build() {
   export CFLAGS='-MT'
   if [[ $envName = windows-arm64 ]]; then
     echo "Targeting aarch64..."
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc -- --no-default-features --features=runtime-opengl
+    cargo run -p librashader-build-script -- --profile ${librashader_profile} --target aarch64-pc-windows-msvc -- --no-default-features --features=runtime-opengl,runtime-d3d11,runtime-d3d12
   else
-    cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --no-default-features --features=runtime-opengl
+    cargo run -p librashader-build-script -- --profile ${librashader_profile} -- --no-default-features --features=runtime-opengl,runtime-d3d11,runtime-d3d12
   fi
   unset RUSTFLAGS CXXFLAGS CFLAGS
   cd ..

--- a/deps.windows/sdl
+++ b/deps.windows/sdl
@@ -1,7 +1,7 @@
 sdl_name='SDL3'
-sdl_version='3.4.0'
+sdl_version='3.4.4'
 sdl_url='https://github.com/libsdl-org/SDL.git'
-sdl_hash='a962f40bbba175e9716557a25d5d7965f134a3d3'
+sdl_hash='5848e584a1b606de26e3dbd1c7e4ecbc34f807a6'
 SDLARGS=("-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded")
 
 ## Build Steps

--- a/deps.windows/slang_shaders
+++ b/deps.windows/slang_shaders
@@ -1,7 +1,7 @@
 slang_shaders_name='slang-shaders'
 slang_shaders_version='1.0'
 slang_shaders_url='https://github.com/libretro/slang-shaders.git'
-slang_shaders_hash='46dcd51d14efd2d49505d932d6b979f141f538d8'
+slang_shaders_hash='d0cbcd0ae6306231df799dc02d753a4c21d9a3d5'
 
 ## Build Steps
 slang_shaders_setup() {


### PR DESCRIPTION
Update SDL to version 3.4.4
Update slang_shaders to commit d0cbcd0
Update librashader to version 0.10.1, and include Direct3D 11 & 12 runtimes

Note: This incorporates the change in PR https://github.com/ares-emulator/ares-deps/pull/16 which would have resulted in a conflict, so I just included it here. That PR can be closed when this is committed. 

