### PR TITLE
Update rust toolchain

### DIFF
--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -37,7 +37,7 @@ librashader_patch() {
   cd librashader
   echo "Pinning nightly Rust version to 2025-05-20"
   echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
+  echo $'channel = \"nightly-2026-05-29\"' >> rust-toolchain.toml
   echo $'targets = [ \"x86_64-apple-darwin\", \"aarch64-apple-darwin\" ]' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -37,7 +37,7 @@ librashader_patch() {
   cd librashader
   echo "Pinning nightly Rust version to 2025-05-20"
   echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"nightly-2025-03-21\"' >> rust-toolchain.toml
+  echo $'channel = \"nightly-2026-05-29\"' >> rust-toolchain.toml
   echo $'targets = [ \"aarch64-pc-windows-msvc\", \"x86_64-pc-windows-msvc\" ]' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"


### PR DESCRIPTION
Update rust toolchain as librashader v0.11.0 requires a more recent version.