### PR TITLE
Update librashader to use the stable Rust branch

### DIFF
--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -35,7 +35,7 @@ librashader_clean() {
 librashader_patch() {
   echo "[librashader] patching source"
   cd librashader
-  echo "Pinning nightly Rust version to 2025-05-20"
+  echo "Pinning Rust version to stable branch"
   echo $'[toolchain]' > rust-toolchain.toml
   echo $'channel = \"stable\"' >> rust-toolchain.toml
   echo $'targets = [ \"x86_64-apple-darwin\", \"aarch64-apple-darwin\" ]' >> rust-toolchain.toml

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -37,7 +37,7 @@ librashader_patch() {
   cd librashader
   echo "Pinning nightly Rust version to 2025-05-20"
   echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"nightly-2026-05-29\"' >> rust-toolchain.toml
+  echo $'channel = \"stable\"' >> rust-toolchain.toml
   echo $'targets = [ \"x86_64-apple-darwin\", \"aarch64-apple-darwin\" ]' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -35,7 +35,7 @@ librashader_clean() {
 librashader_patch() {
   echo "[librashader] patching source"
   cd librashader
-  echo "Pinning nightly Rust version to 2025-05-20"
+  echo "Pinning Rust version to stable branch"
   echo $'[toolchain]' > rust-toolchain.toml
   echo $'channel = \"stable\"' >> rust-toolchain.toml
   echo $'targets = [ \"aarch64-pc-windows-msvc\", \"x86_64-pc-windows-msvc\" ]' >> rust-toolchain.toml

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -37,7 +37,7 @@ librashader_patch() {
   cd librashader
   echo "Pinning nightly Rust version to 2025-05-20"
   echo $'[toolchain]' > rust-toolchain.toml
-  echo $'channel = \"nightly-2026-05-29\"' >> rust-toolchain.toml
+  echo $'channel = \"stable\"' >> rust-toolchain.toml
   echo $'targets = [ \"aarch64-pc-windows-msvc\", \"x86_64-pc-windows-msvc\" ]' >> rust-toolchain.toml
   cd ..
   echo "[librashader] patching source -- success"


### PR DESCRIPTION
chyrran suggested switching to the stable Rust branch as that is what they will be supporting with librashader going forward.